### PR TITLE
Render the content section by section

### DIFF
--- a/src/api/wiki.js
+++ b/src/api/wiki.js
@@ -48,7 +48,9 @@ const getArticle = (lang, title) => {
         nextContent = ''
       }
 
-      if (s.toclevel === 1) nextDescription = s.line
+      if (s.toclevel === 1) {
+        nextDescription = s.line
+      }
 
       const header = 'h' + (s.toclevel + 1)
       const headerLine = `<${header}>${s.line}</${header}>`

--- a/src/api/wiki.js
+++ b/src/api/wiki.js
@@ -30,6 +30,7 @@ const getArticle = (lang, title) => {
     // parse lead as the first section
     const sections = []
     sections.push({
+      imageUrl,
       description: data.lead.description,
       content: data.lead.sections[0].text
     })
@@ -40,8 +41,14 @@ const getArticle = (lang, title) => {
     data.remaining.sections.forEach((s) => {
       // the section starts with every toclevel 1
       if (s.toclevel === 1 && nextDescription) {
+        // search for the first image in the content
+        const doc = parser.parseFromString(nextContent, 'text/html')
+        const imgNode = doc.querySelector('img')
+
         sections.push({
-          description: nextDescription, content: nextContent
+          description: nextDescription,
+          content: nextContent,
+          imageUrl: (imgNode && imgNode.getAttribute('src')) || imageUrl
         })
 
         nextDescription = ''
@@ -65,7 +72,6 @@ const getArticle = (lang, title) => {
 
     return {
       title,
-      imageUrl,
       sections,
       infobox
     }

--- a/src/api/wiki.js
+++ b/src/api/wiki.js
@@ -19,30 +19,51 @@ const getArticle = (lang, title) => {
   const url = `https://${lang}.wikipedia.org/api/rest_v1/page/mobile-sections/${title}`
   return cachedFetch(url, data => {
     const parser = new DOMParser()
-    let content = data.lead.sections[0].text
+    const title = data.lead.displaytitle
+    const imageUrl = data.lead.image && data.lead.image.urls['320']
+
+    // parse info box
     const doc = parser.parseFromString(data.lead.sections[0].text, 'text/html')
     const infoboxNode = doc.querySelector('[class^="infobox"]')
     const infobox = infoboxNode && infoboxNode.outerHTML
 
-    data.remaining.sections.forEach((s) => {
-      const header = 'h' + (s.toclevel + 1)
-      const headerLine = `<${header}>${s.line}</${header}>`
-      content += headerLine
-      content += s.text
+    // parse lead as the first section
+    const sections = []
+    sections.push({
+      description: data.lead.description,
+      content: data.lead.sections[0].text
     })
 
-    // The app is served from the app:// protocol so protocol-relative
-    // image sources don't work.
-    content = content.replace(/src="\/\//gi, 'src="https://')
+    // parse section as the remaining section
+    let nextDescription = ''
+    let nextContent = ''
+    data.remaining.sections.forEach((s) => {
+      // the section starts with every toclevel 1
+      if (s.toclevel === 1 && nextDescription) {
+        sections.push({
+          description: nextDescription, content: nextContent
+        })
 
-    const result = {
-      title: data.lead.displaytitle,
-      description: data.lead.description,
-      imageUrl: data.lead.image && data.lead.image.urls['320'],
-      content,
+        nextDescription = ''
+        nextContent = ''
+      }
+
+      if (s.toclevel === 1) nextDescription = s.line
+
+      const header = 'h' + (s.toclevel + 1)
+      const headerLine = `<${header}>${s.line}</${header}>`
+
+      // The app is served from the app:// protocol so protocol-relative
+      // image sources don't work.
+      nextContent += headerLine + s.text.replace(/src="\/\//gi, 'src="https://')
+    })
+
+    return {
+      title,
+      imageUrl,
+      sections,
       infobox
     }
-    return result
   })
 }
 

--- a/src/api/wiki.js
+++ b/src/api/wiki.js
@@ -55,9 +55,12 @@ const getArticle = (lang, title) => {
       const header = 'h' + (s.toclevel + 1)
       const headerLine = `<${header}>${s.line}</${header}>`
 
+      // add header when it is not h1
+      nextContent += s.toclevel !== 1 ? headerLine : ''
+
       // The app is served from the app:// protocol so protocol-relative
       // image sources don't work.
-      nextContent += headerLine + s.text.replace(/src="\/\//gi, 'src="https://')
+      nextContent += s.text.replace(/src="\/\//gi, 'src="https://')
     })
 
     return {

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -78,20 +78,22 @@ export const Article = ({ lang, title }) => {
                 <div class='line' />
               </Fragment>
             ) }
-            <div class='article-actions' ref={actionsRef}>
-              <div class='article-actions-button' data-selectable data-selected-key='sections'>
-                <img src='images/sections.svg' />
-                <label>Sections</label>
+            { currentSection === 0 && (
+              <div class='article-actions' ref={actionsRef}>
+                <div class='article-actions-button' data-selectable data-selected-key='sections'>
+                  <img src='images/sections.svg' />
+                  <label>Sections</label>
+                </div>
+                <div class='article-actions-button' data-selectable data-selected-key='quickfacts'>
+                  <img src='images/quickfacts.svg' />
+                  <label>Quick Facts</label>
+                </div>
+                <div class='article-actions-button' data-selectable data-selected-key='audio'>
+                  <img src='images/audio.svg' />
+                  <label>Audio</label>
+                </div>
               </div>
-              <div class='article-actions-button' data-selectable data-selected-key='quickfacts'>
-                <img src='images/quickfacts.svg' />
-                <label>Quick Facts</label>
-              </div>
-              <div class='article-actions-button' data-selectable data-selected-key='audio'>
-                <img src='images/audio.svg' />
-                <label>Audio</label>
-              </div>
-            </div>
+            ) }
             <ArticleBody content={article.sections[currentSection].content} />
           </div>
         </div>

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -20,6 +20,7 @@ export const Article = ({ lang, title }) => {
   const [, setNavigation, getCurrent] = useNavigation(actionsRef, 'x')
   const softkey = useSoftkey()
   const [currentSection, setCurrentSection] = useState(0)
+  const imageUrl = article && article.sections[currentSection].imageUrl
 
   if (!article) {
     return 'Loading...'
@@ -31,6 +32,7 @@ export const Article = ({ lang, title }) => {
     softkey.dispatch({ type: 'setOnKeyLeft', event: onKeyLeft })
     softkey.dispatch({ type: 'setOnKeyCenter', event: onKeyCenter })
   }, [])
+
   useEffect(() => {
     setNavigation(0)
   }, [article])
@@ -47,8 +49,6 @@ export const Article = ({ lang, title }) => {
   const goToQuickFacts = () => {
     window.location.hash = `/quickfacts/${lang}/${title}`
   }
-
-  const hasImage = !!article.imageUrl
 
   const pagerEvent = {
     nextPage: () => {
@@ -69,8 +69,8 @@ export const Article = ({ lang, title }) => {
     <Fragment>
       <Pager event={pagerEvent}>
         <div class='page article'>
-          { hasImage && <div class='lead-image' style={{ backgroundImage: `url(${article.imageUrl})` }} /> }
-          <div class={'card' + (hasImage ? ' with-image' : '')}>
+          { imageUrl && <div class='lead-image' style={{ backgroundImage: `url(${imageUrl})` }} /> }
+          <div class={'card' + (imageUrl ? ' with-image' : '')}>
             <div class='title' dangerouslySetInnerHTML={{ __html: article.title }} />
             { article.sections[currentSection].description && (
               <Fragment>

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -71,7 +71,7 @@ export const Article = ({ lang, title }) => {
         <div class='page article'>
           { imageUrl && <div class='lead-image' style={{ backgroundImage: `url(${imageUrl})` }} /> }
           <div class={'card' + (imageUrl ? ' with-image' : '')}>
-            <div class='title' dangerouslySetInnerHTML={{ __html: article.title }} />
+            <div class='title' dangerouslySetInnerHTML={{ __html: article.sections[currentSection].title }} />
             { article.sections[currentSection].description && (
               <Fragment>
                 <div class='desc'>{article.sections[currentSection].description}</div>

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -55,12 +55,13 @@ export const Article = ({ lang, title }) => {
       const sectionLength = article.sections.length
       const nextSection = currentSection + 1
 
-      if (nextSection < sectionLength) setCurrentSection(nextSection)
-      else setCurrentSection(0)
+      setCurrentSection(nextSection < sectionLength ? nextSection : 0)
     },
     prevPage: () => {
       const prevSection = currentSection - 1
-      if (prevSection >= 0) setCurrentSection(prevSection)
+      if (prevSection >= 0) {
+        setCurrentSection(prevSection)
+      }
     }
   }
 

--- a/src/components/Pager.js
+++ b/src/components/Pager.js
@@ -2,9 +2,9 @@ import { h } from 'preact'
 import { useRef } from 'preact/hooks'
 import { useScroll } from 'hooks'
 
-export const Pager = ({ children }) => {
+export const Pager = ({ children, event }) => {
   const containerRef = useRef()
-  useScroll(containerRef, 240, 'x')
+  useScroll(containerRef, 240, 'x', event)
   return (
     <div class='pages-container' ref={containerRef}>
       <div class='pages'>{children}</div>

--- a/src/hooks/useScroll.js
+++ b/src/hooks/useScroll.js
@@ -3,15 +3,32 @@ import { useKeys } from 'hooks'
 export const useScroll = (
   elementRef,
   step,
-  axis
+  axis,
+  event
 ) => {
   const prop = axis === 'x' ? 'scrollLeft' : 'scrollTop'
   useKeys({
     ArrowDown: () => {
+      const previous = elementRef.current[prop]
       elementRef.current[prop] += step
+      const after = elementRef.current[prop]
+
+      // show the next page (section in article)
+      if (previous === after) {
+        event.nextPage()
+        elementRef.current[prop] = 0
+      }
     },
     ArrowUp: () => {
+      const previous = elementRef.current[prop]
       elementRef.current[prop] -= step
+      const after = elementRef.current[prop]
+
+      // show the previous page (section in article)
+      if (previous === after) {
+        event.prevPage()
+        elementRef.current[prop] = 0
+      }
     }
   })
 }


### PR DESCRIPTION
**Before :** Render lead section and all remaining section
**After :** Render lead as the first page, then render the next section with toclevel 1 when continue scrolling

This change updates the **render section by section** when user scroll to the last page.

When a user scrolls up when at the top of the section, will render the previous section's first page, the behavior is not very clear now, therefore we use this solution until we know it.