### PR TITLE
Change "Language setting" to "Language settings"

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -20,7 +20,7 @@
     "centerkey-select": "Select",
     "softkey-close": "Close",
     "language-change": "Change app language",
-    "language-setting": "Language setting",
+    "language-setting": "Language settings",
     "language-setting-message": "Changing the language here will change the language throughout the app, you can also change the language on each article using the article menu",
     "softkey-ok": "Okay",
     "softkey-read": "Read",


### PR DESCRIPTION
More consistent with other apps, and that's also what
the message documentation says.

Feel free to close it if it is supposed to say "Language setting".