### PR TITLE
Encapsulate MW API URL in utils

### DIFF
--- a/src/api/getRandomArticleTitle.js
+++ b/src/api/getRandomArticleTitle.js
@@ -1,16 +1,13 @@
+import { buildMwApiUrl } from 'utils'
 
 export const getRandomArticleTitle = lang => {
-  const baseUrl = `https://${lang}.wikipedia.org/w/api.php`
   const params = {
     action: 'query',
-    format: 'json',
-    formatversion: 2,
-    origin: '*',
     list: 'random',
     rnnamespace: 0,
     rnlimit: 1
   }
-  const url = baseUrl + '?' + Object.keys(params).map(p => `${p}=${params[p]}`).join('&')
+  const url = buildMwApiUrl(lang, params)
   return fetch(url)
     .then(response => response.json())
     .then(data => {

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -1,12 +1,8 @@
-import { cachedFetch } from 'utils'
+import { cachedFetch, buildMwApiUrl } from 'utils'
 
 export const search = (lang, term) => {
-  const baseUrl = `https://${lang}.wikipedia.org/w/api.php`
   const params = {
     action: 'query',
-    format: 'json',
-    formatversion: 2,
-    origin: '*',
     prop: ['description', 'pageimages', 'pageprops'].join('|'),
     piprop: 'thumbnail',
     pilimit: 15,
@@ -17,7 +13,7 @@ export const search = (lang, term) => {
     gpsnamespace: 0,
     gpssearch: encodeURIComponent(term)
   }
-  const url = baseUrl + '?' + Object.keys(params).map(p => `${p}=${params[p]}`).join('&')
+  const url = buildMwApiUrl(lang, params)
   return cachedFetch(url, data => {
     if (!data.query || !data.query.pages) {
       return []

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
 export * from './cachedFetch'
-export * from './viewport'
 export * from './languages'
+export * from './mwApi'
+export * from './viewport'

--- a/src/utils/mwApi.js
+++ b/src/utils/mwApi.js
@@ -1,0 +1,13 @@
+const defautParams = {
+  format: 'json',
+  formatversion: 2,
+  origin: '*'
+}
+
+export const buildMwApiUrl = (lang, params) => {
+  params = Object.assign({}, defautParams, params)
+  const baseUrl = `https://${lang}.wikipedia.org/w/api.php`
+  return baseUrl + '?' + Object.keys(params).map(p => {
+    return `${p}=${encodeURIComponent(params[p])}`
+  }).join('&')
+}


### PR DESCRIPTION
`URLSearchParams` doesn't appear to be working correctly in FF48. This change at least encapsulates the MW url building in one place.