### PR TITLE
Remove comma splice from language-setting-message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -25,7 +25,7 @@
     "softkey-close": "Close",
     "language-change": "Change app language",
     "language-setting": "Language settings",
-    "language-setting-message": "Changing the language here will change the language throughout the app, you can also change the language on each article using the article menu",
+    "language-setting-message": "Changing the language here will change the language throughout the app. You can also change the language on each article using the article menu.",
     "softkey-ok": "Okay",
     "softkey-read": "Read",
     "reference-title": "Reference [$1]",


### PR DESCRIPTION
Splitting it to two sentences for better readability.
It has already been translated as two sentences with a full stop
to several languages, and it should have a full stop
in English as well.