### PR TITLE
Requesting mw api from mobile api

### DIFF
--- a/src/utils/mwApi.js
+++ b/src/utils/mwApi.js
@@ -6,7 +6,7 @@ const defautParams = {
 
 export const buildMwApiUrl = (lang, params) => {
   params = Object.assign({}, defautParams, params)
-  const baseUrl = `https://${lang}.wikipedia.org/w/api.php`
+  const baseUrl = `https://${lang}.m.wikipedia.org/w/api.php`
   return baseUrl + '?' + Object.keys(params).map(p => {
     return `${p}=${encodeURIComponent(params[p])}`
   }).join('&')


### PR DESCRIPTION
when playing with mobile web page and the footer section, I found sometimes the footer will break due to the request is not trigger from mobile version, then I found all the request in mobile web page are `<lang>.m.wikipedia.org/w/api.php`

maybe can someone tell the different? and should we use `m` for all the request?