### PR TITLE
Minor change to useArticleLinksNavigation

### DIFF
--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -42,7 +42,7 @@ const ArticleSection = ({
     }
   }
 
-  useArticleLinksNavigation('Article', lang, contentRef, page, linkHandlers)
+  useArticleLinksNavigation('Article', lang, contentRef, linkHandlers, [page])
 
   return (
     <div class='article-section' ref={contentRef}>

--- a/src/components/ReferencePreview.js
+++ b/src/components/ReferencePreview.js
@@ -5,7 +5,7 @@ import { useI18n, useSoftkey, useArticleLinksNavigation } from 'hooks'
 export const ReferencePreview = ({ reference, lang, close }) => {
   const i18n = useI18n()
   const contentRef = useRef()
-  useArticleLinksNavigation('ReferencePreview', lang, contentRef, 1)
+  useArticleLinksNavigation('ReferencePreview', lang, contentRef)
   useSoftkey('ReferencePreview', {
     right: i18n.i18n('softkey-close'),
     onKeyRight: close

--- a/src/hooks/useArticleLinksNavigation.js
+++ b/src/hooks/useArticleLinksNavigation.js
@@ -16,8 +16,8 @@ export const useArticleLinksNavigation = (
   origin,
   lang,
   contentRef,
-  currentPage,
-  linkHandlers = {}
+  linkHandlers = {},
+  dependencies = []
 ) => {
   const i18n = useI18n()
   const [links, setLinks] = useState([])
@@ -40,6 +40,10 @@ export const useArticleLinksNavigation = (
   const hasLinks = () => links && links.length
 
   useEffect(() => {
+    findAndSetCurrentLink()
+  }, dependencies)
+
+  const findAndSetCurrentLink = () => {
     const visibleLinks = findVisibleLinks(contentRef.current)
     setLinks(visibleLinks)
     if (visibleLinks.length) {
@@ -47,7 +51,7 @@ export const useArticleLinksNavigation = (
     } else {
       setCurrentLink(null)
     }
-  }, [currentPage])
+  }
 
   const defaultLinkHandlers = {
     title: ({ title }) => {
@@ -92,7 +96,7 @@ export const useArticleLinksNavigation = (
     }
   }, [links, currentLink])
 
-  return [currentLink]
+  return [findAndSetCurrentLink]
 }
 
 const makeLinkClickEvent = link => {


### PR DESCRIPTION
the change is because of the article footer

1. add dependencies as the array to allow more state (page:String -> dependencies:[])
2. return `findAndSelectCurrentLink()`, useful for the page that has ajax request (eg: footer page)

please find article footer branch to checkout the usage of `findAndSelectCurrentLink()`