### PR TITLE
Set search image as background image

### DIFF
--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -16,7 +16,7 @@ export const ListView = ({ items, header, containerRef }) => {
               <div class='title' dangerouslySetInnerHTML={{ __html: item.titleHtml || item.title }} />
               { item.description && <div class='description'>{item.description}</div> }
             </div>
-            { item.imageUrl && <div class='img'><img src={item.imageUrl} /></div> }
+            { item.imageUrl && <div class='img' style={{ backgroundImage: `url(${item.imageUrl}) ` }} /> }
             { item.link && <div class='link'><img src='/images/link.svg' /></div> }
           </div>
 

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -16,7 +16,7 @@ export const ListView = ({ items, header, containerRef }) => {
               <div class='title' dangerouslySetInnerHTML={{ __html: item.titleHtml || item.title }} />
               { item.description && <div class='description'>{item.description}</div> }
             </div>
-            { item.imageUrl && <div class='img' style={{ backgroundImage: `url(${item.imageUrl}) ` }} /> }
+            { item.imageUrl && <div class='img' style={{ backgroundImage: `url(${item.imageUrl})` }} /> }
             { item.link && <div class='link'><img src='/images/link.svg' /></div> }
           </div>
 

--- a/style/listview.less
+++ b/style/listview.less
@@ -30,6 +30,7 @@
 				height: 100%;
 				overflow: hidden;
 				display: flex;
+				flex: calc( 100vw - 96px );
 				flex-direction: column;
 				justify-content: center;
 
@@ -51,14 +52,11 @@
 
 			.img {
 				height: 100%;
-				display: inline-block;
-				text-align: right;
-
-				img {
-					width: 38px;
-					height: 38px;
-					border-radius: 4px;
-				}
+				display: flex;
+				flex: auto;
+				background-repeat: no-repeat;
+				background-position: center center;
+				border-radius: 4px;
 			}
 
 			.link {


### PR DESCRIPTION
Currently, the image is being stretched due to the fixed size, the change centers image, similar to the mobile web search page.

| Before  | After |
| ------------- | ------------- |
| <img width="181" alt="Capture1" src="https://user-images.githubusercontent.com/2560096/71748233-30e9ce80-2e72-11ea-9761-d4b96248e07e.PNG">| <img width="179" alt="Capture2" src="https://user-images.githubusercontent.com/2560096/71748234-30e9ce80-2e72-11ea-8398-8da805a2f37e.PNG">|
