### PR TITLE
Quick Facts

### DIFF
--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -18,7 +18,7 @@ describe('Article view', () => {
     cy.enter().downArrow().enter()
     articlePage.title().should('have.text', 'Cat')
     cy.getLeftSoftkeyButton().click()
-    cy.downArrow().downArrow().enter()
+    cy.downArrow().downArrow().downArrow().enter()
     cy.get('input').type('portugues')
     cy.get('.description').should('have.text', 'Gato')
     cy.downArrow().enter()

--- a/src/api/getArticle.js
+++ b/src/api/getArticle.js
@@ -73,6 +73,7 @@ export const getArticle = (lang, title) => {
     })
 
     return {
+      contentLang: lang,
       sections,
       infobox,
       toc,
@@ -134,7 +135,30 @@ const extractPreview = doc => {
 const extractInfobox = doc => {
   const infoboxNode = doc.querySelector('[class^="infobox"]')
   if (infoboxNode) {
+    // Clear a bunch of style that interfere with the layout
     infoboxNode.style.width = ''
+    infoboxNode.style.fontSize = ''
+    const blackListedProps = ['minWidth', 'whiteSpace', 'width']
+    Array.from(infoboxNode.querySelectorAll('[style]')).forEach(n => {
+      blackListedProps.forEach(propName => {
+        if (n.style[propName]) {
+          n.style[propName] = ''
+        }
+      })
+    })
+
+    // Long URLs in content make the table too wide
+    Array.from(infoboxNode.querySelectorAll('a[href]')).forEach(a => {
+      if (a.href === a.textContent) {
+        // Use a shorter text (strip protocol and path)
+        var u = new URL(a.href)
+        a.textContent = u.hostname
+
+        // Constrain the parent node and truncate if needed
+        a.parentNode.classList.add('truncate')
+      }
+    })
+
     return infoboxNode.outerHTML
   }
 }

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -3,7 +3,7 @@ import { memo } from 'preact/compat'
 import { useState, useRef, useEffect } from 'preact/hooks'
 import {
   ReferencePreview, ArticleToc, ArticleLanguage,
-  ArticleMenu, ArticleFooter, Loading
+  ArticleMenu, ArticleFooter, Loading, QuickFacts
 } from 'components'
 import {
   useArticle, useI18n, useSoftkey,
@@ -22,9 +22,9 @@ const ArticleBody = memo(({ content }) => {
 })
 
 const ArticleSection = ({
-  lang, imageUrl, title, description, isFooter,
-  hasActions, content, page, showToc, references,
-  goToSubpage, hasInfobox, articleTitle, suggestedArticles
+  lang, imageUrl, title, description, hasActions, isFooter,
+  content, page, showToc, goToSubpage, references,
+  hasInfobox, articleTitle, suggestedArticles, showQuickFacts
 }) => {
   const contentRef = useRef()
   const i18n = useI18n()
@@ -34,7 +34,7 @@ const ArticleSection = ({
   const linkHandlers = {
     action: ({ action }) => {
       if (action === 'quickfacts') {
-        goto.quickfacts(lang, title)
+        showQuickFacts()
       } else if (action === 'sections') {
         showToc()
       }
@@ -95,6 +95,7 @@ const ArticleInner = ({ lang, articleTitle, initialSubTitle }) => {
 
   const [subTitle, setSubTitle] = useState(initialSubTitle)
   const [showTocPopup] = usePopup(ArticleToc, { mode: 'fullscreen' })
+  const [showQuickFactsPopup] = usePopup(QuickFacts, { mode: 'fullscreen' })
   const [showLanguagePopup] = usePopup(ArticleLanguage, { mode: 'fullscreen' })
   const [showMenuPopup] = usePopup(ArticleMenu, { mode: 'fullscreen' })
   const [currentSection, setCurrentSection, currentPage] = useArticlePagination(containerRef, article, subTitle)
@@ -118,9 +119,22 @@ const ArticleInner = ({ lang, articleTitle, initialSubTitle }) => {
     showLanguagePopup({ lang, title: articleTitle })
   }
 
+  const showQuickFacts = () => {
+    showQuickFactsPopup({ article })
+  }
+
+  const showArticleMenu = () => {
+    showMenuPopup({
+      onTocSelected: showArticleTocPopup,
+      onLanguageSelected: showArticleLanguagePopup,
+      onQuickFactsSelected: showQuickFacts,
+      hasLanguages: article.languageCount
+    })
+  }
+
   useSoftkey('Article', {
     left: i18n.i18n('softkey-menu'),
-    onKeyLeft: () => showMenuPopup({ onTocSelected: showArticleTocPopup, onLanguageSelected: showArticleLanguagePopup, hasLanguages: article.languageCount }),
+    onKeyLeft: showArticleMenu,
     right: i18n.i18n('softkey-close'),
     onKeyRight: () => history.back()
   }, [])
@@ -141,6 +155,7 @@ const ArticleInner = ({ lang, articleTitle, initialSubTitle }) => {
         references={article.references}
         suggestedArticles={article.suggestedArticles}
         showToc={showArticleTocPopup}
+        showQuickFacts={showQuickFacts}
         goToSubpage={goToArticleSubpage}
         page={currentPage}
       />

--- a/src/components/ArticleMenu.js
+++ b/src/components/ArticleMenu.js
@@ -4,7 +4,10 @@ import { useNavigation, useI18n, useSoftkey, usePopup } from 'hooks'
 import { articleHistory, goto } from 'utils'
 import { ListView, TextSize } from 'components'
 
-export const ArticleMenu = ({ close, onTocSelected, onLanguageSelected, hasLanguages }) => {
+export const ArticleMenu = ({
+  close, onTocSelected, onLanguageSelected, hasLanguages,
+  onQuickFactsSelected
+}) => {
   const containerRef = useRef()
   const i18n = useI18n()
   const onKeyCenter = () => {
@@ -42,7 +45,8 @@ export const ArticleMenu = ({ close, onTocSelected, onLanguageSelected, hasLangu
 
   const items = [
     { title: i18n.i18n('article-action-sections'), action: onTocSelected },
-    { title: i18n.i18n('menu-textsize'), action: onTextsizeSelected }
+    { title: i18n.i18n('menu-textsize'), action: onTextsizeSelected },
+    { title: i18n.i18n('article-action-quickfacts'), action: onQuickFactsSelected }
   ]
 
   // add Previous Section item

--- a/src/components/QuickFacts.js
+++ b/src/components/QuickFacts.js
@@ -2,37 +2,42 @@ import { h } from 'preact'
 import { useRef } from 'preact/hooks'
 import { ReferencePreview } from 'components'
 import {
-  useArticle, useScroll, usePopup,
+  useScroll, usePopup, useArticleTextSize,
   useI18n, useSoftkey, useArticleLinksNavigation
 } from 'hooks'
 
-export const QuickFacts = ({ lang, title }) => {
+export const QuickFacts = ({ article, close }) => {
   const i18n = useI18n()
-  const article = useArticle(lang, title)
   const containerRef = useRef()
   const [scrollDown, scrollUp, scrollPosition] = useScroll(containerRef, 20, 'y')
-  const [showReferencePreview] = usePopup(ReferencePreview, { position: 'auto' })
+  const [showReferencePreview] = usePopup(ReferencePreview)
+  const [textSize] = useArticleTextSize('QuickFacts')
   useSoftkey('QuickFacts', {
     right: i18n.i18n('softkey-close'),
-    onKeyRight: () => history.back(),
+    onKeyRight: close,
     onKeyArrowDown: scrollDown,
     onKeyArrowUp: scrollUp
   })
 
-  if (!article) {
-    return 'Loading...'
-  }
-
   const linkHandlers = {
     reference: ({ referenceId }) => {
-      showReferencePreview({ reference: article.references[referenceId], lang })
+      showReferencePreview({
+        reference: article.references[referenceId],
+        lang: article.contentLang
+      })
     }
   }
-  useArticleLinksNavigation('QuickFacts', lang, containerRef, linkHandlers, [scrollPosition])
+  useArticleLinksNavigation(
+    'QuickFacts',
+    article.contentLang,
+    containerRef,
+    linkHandlers,
+    [scrollPosition, textSize]
+  )
 
   return (
     <div
-      class='quickfacts'
+      class='quickfacts adjustable-font-size'
       ref={containerRef}
       dangerouslySetInnerHTML={{ __html: article.infobox }}
     />

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -1,7 +1,7 @@
 import { h } from 'preact'
 import { Router, route } from 'preact-router'
 import { createHashHistory } from 'history'
-import { Article, Search, Settings, QuickFacts, Language, Onboarding } from 'components'
+import { Article, Search, Settings, Language, Onboarding } from 'components'
 import { onboarding } from 'utils'
 
 export const Routes = ({ onRouteChange }) => {
@@ -17,10 +17,7 @@ export const Routes = ({ onRouteChange }) => {
       <Search path='/' />
       <Settings path='/settings' />
       <Article path='/article/:lang/:title/:subtitle?' />
-      <QuickFacts path='/quickfacts/:lang/:title' />
       <Language path='/language' />
     </Router>
   )
 }
-
-// todo: export navigation functions

--- a/style/quickfacts.less
+++ b/style/quickfacts.less
@@ -3,13 +3,42 @@
 	overflow-y: scroll;
 	overflow: -moz-scrollbars-none;
 	height: @availableHeight;
+	width: calc( 100vw );
+
+	& > table {
+		width: calc( 100vw );
+	}
 
 	table {
-		width: 100vw;
-
 		img {
 			max-width: 80vw;
 			height: auto;
 		}
+
+		th:not( [ colspan ] ),
+		td:not( [ colspan ] ) {
+			max-width: 50vw;
+			word-wrap: break-word;
+		}
+
+		.truncate {
+			max-width: 50vw;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		.plainlist {
+			ul {
+				margin: 5px 0;
+				padding: 0;
+			}
+		}
+	}
+
+	.noprint,
+	.wikidata-link,
+	.navigation-only,
+	audio {
+		display: none;
 	}
 }


### PR DESCRIPTION
* Constrain the width for most cases
* Move to a popup instead of a route
* Add article menu entry
* Allow changing text size

https://phabricator.wikimedia.org/T234619

Known issue: Opening and closing a preview from the Quick Facts popup, leads you back to the article, not the quick facts. This is because we don't yet support multiple popups on top of one another. This will be addressed in a subsequent PR.