### PR TITLE
Support multiple popups

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,6 @@
     "viewportWidth": 240,
     "viewportHeight": 290,
     "videoUploadOnPasses":false,
+    "modifyObstructiveCode": false,
     "baseUrl": "http://127.0.0.1:8080"
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,7 +7,7 @@ import { SoftkeyReducer } from 'reducers'
 export const App = ({ i18n }) => {
   // @todo making it used by the global state management
   const [state, dispatch] = useReducer(SoftkeyReducer, {})
-  const [popupState, setPopupState] = useState({})
+  const [popupState, setPopupState] = useState([])
   const [url, setUrl] = useState()
 
   return (
@@ -17,7 +17,7 @@ export const App = ({ i18n }) => {
           <OfflineIndicator routeUrl={url} />
           <Routes onRouteChange={({ url }) => setUrl(url)} />
           <Softkey {...state.current} />
-          <PopupContainer {...popupState} />
+          <PopupContainer popups={popupState} />
         </PopupContext.Provider>
       </SoftkeyContext.Provider>
     </I18nContext.Provider>

--- a/src/components/ArticlePreview.js
+++ b/src/components/ArticlePreview.js
@@ -2,13 +2,13 @@ import { h } from 'preact'
 import { useArticleSummary, useI18n, useSoftkey, useArticleTextSize } from 'hooks'
 import { goto } from 'utils'
 
-export const ArticlePreview = ({ lang, title, close }) => {
+export const ArticlePreview = ({ lang, title, close, closeAll }) => {
   const i18n = useI18n()
   const summary = useArticleSummary(lang, title)
 
   const read = () => {
     const readTitle = summary ? summary.titles.canonical : title
-    close()
+    closeAll()
     goto.article(lang, readTitle, true)
   }
   useSoftkey('ArticlePreview', {

--- a/src/components/PopupContainer.js
+++ b/src/components/PopupContainer.js
@@ -19,14 +19,18 @@ export const PopupContainer = ({ popups }) => {
     return ''
   }
   let zIndex = 100
-  const popupsBeforeShader = popups.length > 1
-    ? popups.slice(0, -1) : []
-  const lastPopup = popups.slice(-1)[0]
+  const nextZIndex = () => {
+    zIndex += 2
+    return zIndex
+  }
+  // The shader is just before the last popup
+  const shaderZIndex = 100 + popups.length * 2 - 1
   return (
     <div class='popup'>
-      { popupsBeforeShader.map(popup => <Popup {...popup} style={{ zIndex: zIndex++ }} />) }
-      <div class='shader' style={{ zIndex: zIndex++ }} />
-      <Popup {...lastPopup} style={{ zIndex: zIndex++ }} />
+      <div class='shader' style={{ zIndex: shaderZIndex }} />
+      { popups.map(popup => {
+        return <Popup {...popup} key={popup.id} style={{ zIndex: nextZIndex() }} />
+      }) }
     </div>
   )
 }

--- a/src/components/PopupContainer.js
+++ b/src/components/PopupContainer.js
@@ -1,18 +1,32 @@
 import { h } from 'preact'
 
-export const PopupContainer = ({ component, props, options }) => {
+export const Popup = ({ component, props, options, style }) => {
   if (component) {
     let contentClasses = 'popup-content'
     if (options && options.mode === 'fullscreen') {
       contentClasses += ' fullscreen'
     }
     return (
-      <div class='popup'>
-        <div class='shader' />
-        <div class={contentClasses}>
-          { h(component, props) }
-        </div>
+      <div class={contentClasses} style={style}>
+        { h(component, props) }
       </div>
     )
   }
+}
+
+export const PopupContainer = ({ popups }) => {
+  if (popups.length === 0) {
+    return ''
+  }
+  let zIndex = 100
+  const popupsBeforeShader = popups.length > 1
+    ? popups.slice(0, -1) : []
+  const lastPopup = popups.slice(-1)[0]
+  return (
+    <div class='popup'>
+      { popupsBeforeShader.map(popup => <Popup {...popup} style={{ zIndex: zIndex++ }} />) }
+      <div class='shader' style={{ zIndex: zIndex++ }} />
+      <Popup {...lastPopup} style={{ zIndex: zIndex++ }} />
+    </div>
+  )
 }

--- a/src/components/QuickFacts.js
+++ b/src/components/QuickFacts.js
@@ -10,7 +10,7 @@ export const QuickFacts = ({ article, close }) => {
   const i18n = useI18n()
   const containerRef = useRef()
   const [scrollDown, scrollUp, scrollPosition] = useScroll(containerRef, 20, 'y')
-  const [showReferencePreview] = usePopup(ReferencePreview)
+  const [showReferencePreview] = usePopup(ReferencePreview, { stack: true })
   const [textSize] = useArticleTextSize('QuickFacts')
   useSoftkey('QuickFacts', {
     right: i18n.i18n('softkey-close'),

--- a/src/hooks/useArticleLinksNavigation.js
+++ b/src/hooks/useArticleLinksNavigation.js
@@ -24,7 +24,7 @@ export const useArticleLinksNavigation = (
   const [links, setLinks] = useState([])
   const [currentLink, setCurrentLinkInternal] = useState(null)
 
-  const [showArticlePreview] = usePopup(ArticlePreview, { position: 'bottom' })
+  const [showArticlePreview] = usePopup(ArticlePreview, { position: 'bottom', stack: true })
 
   const setCurrentLink = newLink => {
     setCurrentLinkInternal(previousLink => {

--- a/src/hooks/useArticleLinksNavigation.js
+++ b/src/hooks/useArticleLinksNavigation.js
@@ -24,7 +24,7 @@ export const useArticleLinksNavigation = (
   const [links, setLinks] = useState([])
   const [currentLink, setCurrentLinkInternal] = useState(null)
 
-  const [showArticlePreview] = usePopup(ArticlePreview, { position: 'bottom', stack: true })
+  const [showArticlePreview] = usePopup(ArticlePreview, { stack: true })
 
   const setCurrentLink = newLink => {
     setCurrentLinkInternal(previousLink => {

--- a/src/hooks/usePopup.js
+++ b/src/hooks/usePopup.js
@@ -11,6 +11,11 @@ export const usePopup = (component, options = {}) => {
       return newState
     })
   }
+
+  const closeAll = () => {
+    setPopupState([])
+  }
+
   const show = props => {
     setPopupState(oldState => {
       let newState = [...oldState]
@@ -18,7 +23,8 @@ export const usePopup = (component, options = {}) => {
         component,
         props: {
           ...props,
-          close
+          close,
+          closeAll
         },
         options,
         id: Math.random()

--- a/src/hooks/usePopup.js
+++ b/src/hooks/usePopup.js
@@ -1,15 +1,8 @@
-import { useContext, useEffect } from 'preact/hooks'
+import { useContext } from 'preact/hooks'
 import { PopupContext } from 'contexts'
 
 export const usePopup = (component, options = {}) => {
   const { setPopupState } = useContext(PopupContext)
-
-  useEffect(() => {
-    return () => {
-      // clear all the popups when the current component unmounts
-      setPopupState([])
-    }
-  }, [])
 
   const close = () => {
     setPopupState(oldState => {
@@ -27,7 +20,8 @@ export const usePopup = (component, options = {}) => {
           ...props,
           close
         },
-        options
+        options,
+        id: Math.random()
       }
       if (options.stack) {
         newState.push(newPopup)

--- a/src/hooks/usePopup.js
+++ b/src/hooks/usePopup.js
@@ -1,18 +1,40 @@
-import { useContext } from 'preact/hooks'
+import { useContext, useEffect } from 'preact/hooks'
 import { PopupContext } from 'contexts'
 
 export const usePopup = (component, options = {}) => {
   const { setPopupState } = useContext(PopupContext)
+
+  useEffect(() => {
+    return () => {
+      // clear all the popups when the current component unmounts
+      setPopupState([])
+    }
+  }, [])
+
+  const close = () => {
+    setPopupState(oldState => {
+      const newState = [...oldState]
+      newState.pop()
+      return newState
+    })
+  }
   const show = props => {
-    setPopupState({
-      component,
-      props: {
-        ...props,
-        close: () => {
-          setPopupState(null)
-        }
-      },
-      options
+    setPopupState(oldState => {
+      let newState = [...oldState]
+      const newPopup = {
+        component,
+        props: {
+          ...props,
+          close
+        },
+        options
+      }
+      if (options.stack) {
+        newState.push(newPopup)
+      } else {
+        newState = [newPopup]
+      }
+      return newState
     })
   }
   return [show]

--- a/style/popup.less
+++ b/style/popup.less
@@ -2,7 +2,6 @@
 	z-index: 100;
 
 	.shader {
-		z-index: 101;
 		position: absolute;
 		top: 0;
 		right: 0;
@@ -14,7 +13,6 @@
 
 	.popup-content {
 		overflow: hidden;
-		z-index: 102;
 		position: absolute;
 		max-height: 80vh;
 		right: 0;


### PR DESCRIPTION
This is useful for situation where a popup brings another popup and closing the second one should return to the first one. For instance, showing article previews on top of quick facts.