### PR TITLE
Fix bottom style in menu

### DIFF
--- a/style/menu.less
+++ b/style/menu.less
@@ -1,7 +1,7 @@
 .menu {
 	.list {
 		top: @pageHeaderHeight;
-		bottom: @softkeysHeight;
+		bottom: 0;
 
 		.item .info .title {
 			font-family: @textFont;


### PR DESCRIPTION
Fix weird error bottom in menu listview, when the menu list item is larger, then we will get

<img width="181" alt="Capture" src="https://user-images.githubusercontent.com/2560096/73136996-db7a9900-408e-11ea-9e2c-7f98d2507032.PNG">

This css change fixed.

<img width="181" alt="Capture" src="https://user-images.githubusercontent.com/2560096/73137018-fd741b80-408e-11ea-90d5-1a72e5aa3e64.PNG">
