### PR TITLE
Block namespace search

### DIFF
--- a/src/api/search.js
+++ b/src/api/search.js
@@ -8,10 +8,11 @@ export const search = (lang, term) => {
     pilimit: 15,
     ppprop: 'displaytitle',
     generator: 'prefixsearch',
+    redirects: true,
     pithumbsize: 64,
     gpslimit: 15,
     gpsnamespace: 0,
-    gpssearch: term
+    gpssearch: term.replace(/:/g, ' ')
   }
   const url = buildMwApiUrl(lang, params)
   return cachedFetch(url, data => {


### PR DESCRIPTION
It is possible to search for pages that are not articles
by using a namespce preffix in the search terms.
For instance: Help:Style, User_talk:SomeUserName,
or even Special:AbuseFilter

None of those results are relevant for this application.

This commit blocks those by replacing all colons with spaces.

It is possible for an article title to contain a colon but
very few do. And those who do generally have a redirect
from a similar title without it. I've included the "redirects"
API option to resolve redirects and mitigate the impact of
ommiting the colon.