### PR TITLE
Remove "test wiki" from the language list

### DIFF
--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1440,11 +1440,6 @@ const languages = [
     canonical_name: 'Herero',
     code: 'hz',
     name: 'Otsiherero'
-  },
-  {
-    canonical_name: 'Test Wiki',
-    code: 'test',
-    name: 'Test Wiki'
   }
 ]
 


### PR DESCRIPTION
Test wiki is a site (for testing) in the production cluster but not a language.