### PR TITLE
Header page positioning when text resizes

### DIFF
--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -74,12 +74,16 @@ const ArticleSection = ({
       titleNode.classList.add('clamp')
     }
     if (imageUrl) {
+      const cardNode = contentRef.current.querySelector('.card')
+      // Ensure .intro is completely visible to calculate its size
+      cardNode.style.marginTop = 0
+
       const introNode = contentRef.current.querySelector('.intro')
       let introHeight = introNode.getBoundingClientRect().height
       introHeight += 34 // Magic number needed to make it work
       const articleSectionHeight = contentRef.current.getBoundingClientRect().height
       const marginTop = articleSectionHeight - introHeight
-      const cardNode = contentRef.current.querySelector('.card')
+
       cardNode.style.marginTop = `${marginTop}px`
     }
   }, [title, imageUrl, textSize])


### PR DESCRIPTION
After the initial rendering of the article header page,
The .card component is added a margin-top to make sure
the .intro component fits perfectly at the bottom of
the page.

On text resize (make larger, 6), the .intro component
overflows to the next page and its height is reported
as bigger than it actually is. This causes the algorithm
to push the intro all the way up.

This commit resets the .card margin-top to 0 to make sure
the .intro is entirely visible.