### PR TITLE
Gallery doesn't repeat when it reaches the end

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -60,7 +60,9 @@ export const Gallery = ({ close, items }) => {
 
   const onNextImage = () => {
     const nextIndex = currentIndex + 1
-    setCurrentIndex(nextIndex % items.length)
+    if (nextIndex < items.length) {
+      setCurrentIndex(nextIndex)
+    }
   }
 
   const onPrevImage = () => {


### PR DESCRIPTION
Phabricator Link : https://phabricator.wikimedia.org/T236302#5879391

### Problem Statement

Currently, it does cycle the gallery item

### Solution

do not repeat when reaches the end of last gallery item

### Note
