### PR TITLE
:bug: Use anchor instead title for sub page

### DIFF
--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -58,7 +58,7 @@ const ArticleSection = ({
     },
     section: ({ text, anchor }) => {
       // @todo styling to be confirmed with design
-      confirmDialog({ message: i18n.i18n('confirm-section', text), onSubmit: () => goToSubpage({ title: anchor }) })
+      confirmDialog({ message: i18n.i18n('confirm-section', text), onSubmit: () => goToSubpage({ anchor }) })
     }
   }
 


### PR DESCRIPTION
Phabricator Link : -

### Problem Statement

Selecting the section doesn't work in the article

### Solution

This is the bug fixed of https://github.com/wikimedia/wikipedia-kaios/pull/127, as we change to `anchor` instead of using the section `title`
