### PR TITLE
Change All Caps language key

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -50,7 +50,7 @@
     "softkey-skip": "Skip",
     "softkey-get-started": "Get started",
     "softkey-refresh": "Refresh",
-    "suggested-articles": "SUGGESTED ARTICLES",
+    "suggested-articles": "Suggested articles",
     "reference-title": "Reference [$1]",
     "offline-message": "No internet connection ",
     "onboarding-0-title": "The free encyclopedia",


### PR DESCRIPTION
Phabricator Link : https://phabricator.wikimedia.org/T243413

### Problem Statement

There is ALL CAPS language key in en.json that is not recommended.

### Solution

Follow the same pattern as other language keys

### Note

This key is being used in Article Footer as the title keyword.