### PR TITLE
Hide skip top and bottom button in article view

### DIFF
--- a/style/article.less
+++ b/style/article.less
@@ -183,6 +183,13 @@
 				blockquote {
 					margin: 10px;
 				}
+
+				/* stylelint-disable */
+				#skip-to-top-button,
+				#skip-to-bottom-button {
+					display: none;
+				}
+				/* stylelint-enable */
 			}
 		}
 	}


### PR DESCRIPTION
Phabricator Link : -

### Problem Statement

in some articles, it shows the skip top and bottom button on the view, see note screenshot

article `2019` http://localhost:8080/#/article/en/2019
### Solution

hide

### Note

<img width="181" alt="Capture" src="https://user-images.githubusercontent.com/2560096/75122325-8eddaa00-569c-11ea-8912-5786bfb3c776.PNG">
