### PR TITLE
Switch article image background-size from cover to contain

### DIFF
--- a/style/article.less
+++ b/style/article.less
@@ -20,7 +20,7 @@
 		// This prevents long words like URLs from overflowing
 		// onto the next column.
 		word-wrap: break-word;
-		background-size: cover;
+		background-size: contain;
 		background-position: center;
 		background-repeat: no-repeat;
 


### PR DESCRIPTION
Phabricator Link : https://phabricator.wikimedia.org/T244821

### Problem Statement

Bigger size images at the article top are sometimes unrecognizable.

### Solution

Updating `background-size` before and after results:

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/4752599/75202693-ad41b500-5731-11ea-91ec-7cc650839f67.png" width=200> | <img src="https://user-images.githubusercontent.com/4752599/75202705-b5015980-5731-11ea-94eb-60200ac727aa.png" width=200> |
| <img src="https://user-images.githubusercontent.com/4752599/75202757-e5e18e80-5731-11ea-9b54-e86dcd04d5ac.png" width=200> | <img src="https://user-images.githubusercontent.com/4752599/75202760-eb3ed900-5731-11ea-831d-18b2789d2f03.png" width=200> |
| <img src="https://user-images.githubusercontent.com/4752599/75203253-48875a00-5733-11ea-9308-bc7381762d6b.png" width=200> | <img src="https://user-images.githubusercontent.com/4752599/75203259-4d4c0e00-5733-11ea-9a93-36cdec7120ec.png" width=200> |


