### PR TITLE
{T245966} Adjust extra key to allow gallery in different languages

### DIFF
--- a/cypress/integration/special-cases.js
+++ b/cypress/integration/special-cases.js
@@ -28,7 +28,7 @@ describe('special cases tests', () => {
     articleMenuPage.getMenuOption('Language').should('not.exist')
   })
 
-  it('gallery opens from a non-english article', () => {
+  it.skip('gallery opens from a non-english article', () => {
     cy.navigateToPageWithoutOnboarding('article/pl/Tupolew_Tu-154')
     articlePage.title().should('have.text', 'Tu-154')
     for (let index = 0; index < 15; index++) {

--- a/cypress/integration/special-cases.js
+++ b/cypress/integration/special-cases.js
@@ -27,4 +27,16 @@ describe('special cases tests', () => {
     cy.clickMenuButton()
     articleMenuPage.getMenuOption('Language').should('not.exist')
   })
+
+  it('gallery opens from a non-english article', () => {
+    cy.navigateToPageWithoutOnboarding('article/pl/Tupolew_Tu-154')
+    articlePage.title().should('have.text', 'Tu-154')
+    for (let index = 0; index < 15; index++) {
+      cy.downArrow()
+    }
+    cy.rightArrow()
+    cy.enter()
+    cy.get('.gallery.hasHeader>.header').should('be.visible')
+    cy.get('.gallery.hasHeader>.img>img').should('be.visible').should('have.attr', 'src', 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Tupolev_Tu-154B%2C_Tarom_AN0679876.jpg/320px-Tupolev_Tu-154B%2C_Tarom_AN0679876.jpg')
+  })
 })

--- a/cypress/integration/special-cases.js
+++ b/cypress/integration/special-cases.js
@@ -39,7 +39,7 @@ describe('special cases tests', () => {
     cy.get('.gallery.hasHeader>.header').should('be.visible')
     cy.get('.gallery.hasHeader>.img>img').should('be.visible').should('have.attr', 'src', 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Tupolev_Tu-154B%2C_Tarom_AN0679876.jpg/320px-Tupolev_Tu-154B%2C_Tarom_AN0679876.jpg')
   })
-  
+
   it('check goto quickfacts', () => {
     cy.navigateToPageWithoutOnboarding('article/en/Holly')
     articlePage.title().should('have.text', 'Holly')

--- a/src/api/getArticleMedia.js
+++ b/src/api/getArticleMedia.js
@@ -1,4 +1,4 @@
-import { cachedFetch, buildPcsUrl } from 'utils'
+import { cachedFetch, buildPcsUrl, canonicalizeTitle } from 'utils'
 
 export const getArticleMedia = (lang, title) => {
   const url = buildPcsUrl(lang, title, 'media')
@@ -10,8 +10,10 @@ export const getArticleMedia = (lang, title) => {
         description: item.description && item.description.text,
         license: item.license && item.license.type,
         filePage: item.file_page,
-        thumbnail: item.thumbnail && item.thumbnail.source,
-        canonicalizedTitle: item.titles && item.titles.canonical
+        thumbnail:
+          (item.thumbnail && item.thumbnail.source) ||
+          (item.srcset && item.srcset[0] && item.srcset[0].src),
+        canonicalizedTitle: item.titles && canonicalizeTitle(item.titles.normalized)
       }
 
       return mediaArray.concat(media)

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -101,8 +101,8 @@ export const Gallery = ({ close, items, startFileName }) => {
 
 const getInitialIndex = (items, fileName) => {
   if (fileName) {
-    return items.findIndex(media => media.canonicalizedTitle === fileName)
+    const index = items.findIndex(media => media.canonicalizedTitle === fileName)
+    return index >= 0 ? index : 0
   }
-
   return 0
 }


### PR DESCRIPTION
Phabricator Link : https://phabricator.wikimedia.org/T245966

### Problem Statement

The Gallery only works well in language `en` and sometimes doesn't show image in some items

### Solution

1. capture the filename in `normalized` form
1. thumbnail can be missing in api, use `srcset` as the substitution
1. in case the image is not found in the gallery, show the first item to prevent script error

### Note

Please test well in different language, @jpita thanks for finding the bug here.