### PR TITLE
Request native language name in getLanglinks

### DIFF
--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -21,7 +21,7 @@ describe('Article view', () => {
   it('change article language', () => {
     goToCatArticle()
     articlePage.selectOptionFromActionsMenu('languages')
-    cy.get('input').type('portugues')
+    cy.get('input').type('português')
     cy.get('.description').should('have.text', 'Gato')
     cy.downArrow().enter()
     cy.clickDoneButton()

--- a/src/api/getLanglinks.js
+++ b/src/api/getLanglinks.js
@@ -6,14 +6,14 @@ export const getLanglinks = (lang, title) => {
     titles: title,
     prop: 'langlinks',
     lllimit: 500,
-    llprop: 'langname'
+    llprop: 'autonym'
   }
   const url = buildMwApiUrl(lang, params)
   return cachedFetch(url, response => {
     const { pages } = response.query
     return pages[0].langlinks.map(item => (
       {
-        title: item.langname,
+        title: item.autonym,
         lang: item.lang,
         description: item.title
       }

--- a/src/api/getLanglinks.js
+++ b/src/api/getLanglinks.js
@@ -6,14 +6,14 @@ export const getLanglinks = (lang, title) => {
     titles: title,
     prop: 'langlinks',
     lllimit: 500,
-    llprop: 'autonym'
+    llprop: 'langname|autonym'
   }
   const url = buildMwApiUrl(lang, params)
   return cachedFetch(url, response => {
     const { pages } = response.query
     return pages[0].langlinks.map(item => (
       {
-        title: item.autonym,
+        title: [item.langname, item.autonym],
         lang: item.lang,
         description: item.title
       }

--- a/src/api/getLanglinks.js
+++ b/src/api/getLanglinks.js
@@ -13,7 +13,8 @@ export const getLanglinks = (lang, title) => {
     const { pages } = response.query
     return pages[0].langlinks.map(item => (
       {
-        title: [item.langname, item.autonym],
+        title: item.langname,
+        autonym: item.autonym,
         lang: item.lang,
         description: item.title
       }

--- a/src/api/getLanglinks.js
+++ b/src/api/getLanglinks.js
@@ -13,8 +13,8 @@ export const getLanglinks = (lang, title) => {
     const { pages } = response.query
     return pages[0].langlinks.map(item => (
       {
-        title: item.langname,
-        autonym: item.autonym,
+        title: item.autonym,
+        langname: item.langname,
         lang: item.lang,
         description: item.title
       }

--- a/src/components/RadioListView.js
+++ b/src/components/RadioListView.js
@@ -6,21 +6,17 @@ export const RadioListView = ({ items = [], header, containerRef, empty }) => {
       { header && <div class='header'>{header}</div> }
       <div class='list' ref={containerRef}>
         {
-          items.length ? items.map(item => {
-            let title
-            Array.isArray(item.title) ? title = item.title[0] : title = item.title
-            return (
-              <div class='item' data-selectable data-title={title} data-selected-key={title} key={title}>
-                <div class='info'>
-                  <div class='title'>{title}</div>
-                  { item.description && <div class='description'>{item.description}</div> }
-                </div>
-                <div class='radio-container'>
-                  <div class={`radio ${item.isSelected ? 'selected' : ''}`} />
-                </div>
+          items.length ? items.map(item => (
+            <div class='item' data-selectable data-title={item.title} data-selected-key={item.title} key={item.title}>
+              <div class='info'>
+                <div class='title'>{item.title}</div>
+                { item.description && <div class='description'>{item.description}</div> }
               </div>
-            )
-          }) : <div class='empty'>{empty}</div>
+              <div class='radio-container'>
+                <div class={`radio ${item.isSelected ? 'selected' : ''}`} />
+              </div>
+            </div>
+          )) : <div class='empty'>{empty}</div>
         }
       </div>
     </div>

--- a/src/components/RadioListView.js
+++ b/src/components/RadioListView.js
@@ -6,17 +6,21 @@ export const RadioListView = ({ items = [], header, containerRef, empty }) => {
       { header && <div class='header'>{header}</div> }
       <div class='list' ref={containerRef}>
         {
-          items.length ? items.map(item => (
-            <div class='item' data-selectable data-title={item.title} data-selected-key={item.title} key={item.title}>
-              <div class='info'>
-                <div class='title'>{item.title}</div>
-                { item.description && <div class='description'>{item.description}</div> }
+          items.length ? items.map(item => {
+            let title
+            Array.isArray(item.title) ? title = item.title[0] : title = item.title
+            return (
+              <div class='item' data-selectable data-title={title} data-selected-key={title} key={title}>
+                <div class='info'>
+                  <div class='title'>{title}</div>
+                  { item.description && <div class='description'>{item.description}</div> }
+                </div>
+                <div class='radio-container'>
+                  <div class={`radio ${item.isSelected ? 'selected' : ''}`} />
+                </div>
               </div>
-              <div class='radio-container'>
-                <div class={`radio ${item.isSelected ? 'selected' : ''}`} />
-              </div>
-            </div>
-          )) : <div class='empty'>{empty}</div>
+            )
+          }) : <div class='empty'>{empty}</div>
         }
       </div>
     </div>

--- a/src/hooks/useSearchArticleLanguage.js
+++ b/src/hooks/useSearchArticleLanguage.js
@@ -37,7 +37,8 @@ const filterFirst10Language = (languages, text) => {
   const foundList = []
   for (let i = 0; foundList.length < 10 && i < languages.length; i++) {
     if (
-      languages[i].title.toLowerCase().indexOf(lowerCaseText) > -1 ||
+      languages[i].title[0].toLowerCase().indexOf(lowerCaseText) > -1 ||
+      languages[i].title[1].toLowerCase().indexOf(lowerCaseText) > -1 ||
       languages[i].description.toLowerCase().indexOf(lowerCaseText) > -1 ||
       languages[i].lang.toLowerCase().indexOf(lowerCaseText) > -1
     ) {

--- a/src/hooks/useSearchArticleLanguage.js
+++ b/src/hooks/useSearchArticleLanguage.js
@@ -38,7 +38,7 @@ const filterFirst10Language = (languages, text) => {
   for (let i = 0; foundList.length < 10 && i < languages.length; i++) {
     if (
       languages[i].title.toLowerCase().indexOf(lowerCaseText) > -1 ||
-      languages[i].autonym.toLowerCase().indexOf(lowerCaseText) > -1 ||
+      languages[i].langname.toLowerCase().indexOf(lowerCaseText) > -1 ||
       languages[i].description.toLowerCase().indexOf(lowerCaseText) > -1 ||
       languages[i].lang.toLowerCase().indexOf(lowerCaseText) > -1
     ) {

--- a/src/hooks/useSearchArticleLanguage.js
+++ b/src/hooks/useSearchArticleLanguage.js
@@ -37,8 +37,8 @@ const filterFirst10Language = (languages, text) => {
   const foundList = []
   for (let i = 0; foundList.length < 10 && i < languages.length; i++) {
     if (
-      languages[i].title[0].toLowerCase().indexOf(lowerCaseText) > -1 ||
-      languages[i].title[1].toLowerCase().indexOf(lowerCaseText) > -1 ||
+      languages[i].title.toLowerCase().indexOf(lowerCaseText) > -1 ||
+      languages[i].autonym.toLowerCase().indexOf(lowerCaseText) > -1 ||
       languages[i].description.toLowerCase().indexOf(lowerCaseText) > -1 ||
       languages[i].lang.toLowerCase().indexOf(lowerCaseText) > -1
     ) {


### PR DESCRIPTION
Phabricator Link : https://phabricator.wikimedia.org/T245712

### Problem Statement

As described in the [Phabricator ticket](https://phabricator.wikimedia.org/T245712), what's desired is that languages are searched with the native name ("english") instead of the localized name ("inglês")

### Solution

Switching `llprop` field from `langname` to `autonym` in `getLanglinks` api

### Note

https://www.mediawiki.org/wiki/API:Langlinks
