### PR TITLE
T245564 readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,18 @@
 
 The official Wikipedia KaiOS app. [KaiOS](https://developer.kaiostech.com/) is a web-based mobile operating system that enables a new category of smart feature phones, a successor of the discontinued Firefox OS.
 
-KaiOS applications are similar to Progressive Web Apps (PWAs):
-* Pure web applications
-* Manifest file
-* Installed on the device
-* Have access to the required APIs for notifications, offline, storage, audio, etc
+The Wikipedia KaiOS app is built with [Preact](https://github.com/preactjs/preact) and we use [Cypress](https://github.com/cypress-io/cypress) for testing. Tasks and issues are tracked on [Phabricator](https://phabricator.wikimedia.org/project/profile/4305/).
 
-They are also different:
-* Format of the manifest is different
-* Size of the icons is specific to KaiOS
-* Need to be designed for a small, non-touch screen with a few physical buttons
-* Several APIs are specific to the platform (not web standards)
-* Running performance on the device
-
-The Wikipedia KaiOS app is built with [Preact](https://preactjs.com/) and we use [Cypress](https://www.cypress.io/) for testing. Tasks and issues are tracked on [Phabricator](https://phabricator.wikimedia.org/project/profile/4305/).
-
-## Installation requirements
+## Installation requirements (for macOS)
 
 * Make sure git is installed: `brew install git`
 * Make sure node is installed: `node -v` or `brew install node`
 * Make sure npm is installed: `npm -v` or `brew install npm`
+* Make sure the [Firefox browser is installed](https://www.mozilla.org/en-US/firefox/new/)
 
-## To run this app in your browser
+## To run this app in Firefox
 
-### Clone the app (only the first time)
+### Clone the repository (only the first time)
 
 1. Create a directory for code: `mkdir ~/code && cd ~/code`
 2. Download the app source repository: `git clone https://github.com/wikimedia/wikipedia-kaios.git`
@@ -38,11 +26,11 @@ The Wikipedia KaiOS app is built with [Preact](https://preactjs.com/) and we use
 3. Install app dependencies: `npm install`
 4. Build the app: `npm run dev`
 
-Now the app is running on your computer at http://127.0.0.1:8080  on your browser
+Now the app is running on your computer at http://127.0.0.1:8080  in Firefox. You can open the [Firefox Developer Tools](https://developer.mozilla.org/en-US/docs/Tools) and use the [Responsive Design Mode](https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode) to interact with the app in a more appropiate setting.
 
 ## To run this app on a device
 
-### Clone the app (if you haven't done this alredy)
+### Clone the repository (if you haven't done this alredy)
 
 1. Create a directory for code: `mkdir ~/code && cd ~/code`
 2. Download the app source repository: `git clone https://github.com/wikimedia/wikipedia-kaios.git`
@@ -60,7 +48,7 @@ Now the app is running on your computer at http://127.0.0.1:8080  on your browse
 _Steps 2, 3 and 4 need to be redone when you disconnect and reconnect your device or restart your computer._
 
 ### Deploy the app to the device
-1. Deploy to device, this may take a few minutes: `npm run deploy`
+1. Deploy to device, this will take a few minutes: `npm run deploy`
 
 The Wikipedia app should be running on your device now.
 
@@ -73,7 +61,7 @@ The Wikipedia app should be running on your device now.
 `npm test`
 
 ### To open cypress and run inside cypress
-`npm run cypress`
+`npm run cypress:open`
 
 ## To keep app updated with latest version
 
@@ -82,10 +70,3 @@ The Wikipedia app should be running on your device now.
 3. Install latest dependencies: `npm install`
 4. Rebuild the app: `npm run build`
 5. Redeploy the app: `npm run deploy`
-
----
-
-<p align="center">
-    <img src="https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/1122px-Wikipedia-logo-v2.svg.png" width="200" title="wikipedia-logo">
-</p>
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The official Wikipedia KaiOS app. [KaiOS](https://developer.kaiostech.com/) is a web-based mobile operating system that enables a new category of smart feature phones, a successor of the discontinued Firefox OS.
 
-The Wikipedia KaiOS app is built with [Preact](https://github.com/preactjs/preact) and we use [Cypress](https://github.com/cypress-io/cypress) for testing. Tasks and issues are tracked on [Phabricator](https://phabricator.wikimedia.org/project/profile/4305/).
+The Wikipedia KaiOS app is built with [Preact](https://github.com/preactjs/preact), we use [Cypress](https://github.com/cypress-io/cypress) for testing, and [Translatewiki](https://github.com/wikimedia/translatewiki) for translations. Tasks and issues are tracked on [Phabricator](https://phabricator.wikimedia.org/project/profile/4305/).
 
 ## Installation requirements (for macOS)
 
@@ -44,8 +44,6 @@ Now the app is running on your computer at http://127.0.0.1:8080  in Firefox. Yo
 1. Connect your device to your computer using a USB cable
 2. Enable debug mode on the device by typing: `*#*#33284#*#*`
 3. Check that adb is running and sees your device: `adb devices`
-
-_Steps 2, 3 and 4 need to be redone when you disconnect and reconnect your device or restart your computer._
 
 ### Deploy the app to the device
 1. Deploy to device, this will take a few minutes: `npm run deploy`

--- a/README.md
+++ b/README.md
@@ -2,14 +2,90 @@
 
 # Wikipedia KaiOS 
 
-The official Wikipedia KaiOS app.
+The official Wikipedia KaiOS app. [KaiOS](https://developer.kaiostech.com/) is a web-based mobile operating system that enables a new category of smart feature phones, a successor of the discontinued Firefox OS.
 
-Tasks and issues are tracked on [Phabricator](https://phabricator.wikimedia.org/project/profile/4305/).
+KaiOS applications are similar to Progressive Web Apps (PWAs):
+* Pure web applications
+* Manifest file
+* Installed on the device
+* Have access to the required APIs for notifications, offline, storage, audio, etc
+
+They are also different:
+* Format of the manifest is different
+* Size of the icons is specific to KaiOS
+* Need to be designed for a small, non-touch screen with a few physical buttons
+* Several APIs are specific to the platform (not web standards)
+* Running performance on the device
+
+The Wikipedia KaiOS app is built with [Preact](https://preactjs.com/) and we use [Cypress](https://www.cypress.io/) for testing. Tasks and issues are tracked on [Phabricator](https://phabricator.wikimedia.org/project/profile/4305/).
+
+## Installation requirements
+
+* Make sure git is installed: `brew install git`
+* Make sure node is installed: `node -v` or `brew install node`
+* Make sure npm is installed: `npm -v` or `brew install npm`
+
+## To run this app in your browser
+
+### Clone the app (only the first time)
+
+1. Create a directory for code: `mkdir ~/code && cd ~/code`
+2. Download the app source repository: `git clone https://github.com/wikimedia/wikipedia-kaios.git`
+
+### Open the app on your computer
+1. Make sure you are in the source directory: `cd wikipedia-kaios`
+2. Downloading the latest code: `git pull`
+3. Install app dependencies: `npm install`
+4. Build the app: `npm run dev`
+
+Now the app is running on your computer at http://127.0.0.1:8080  on your browser
+
+## To run this app on a device
+
+### Clone the app (if you haven't done this alredy)
+
+1. Create a directory for code: `mkdir ~/code && cd ~/code`
+2. Download the app source repository: `git clone https://github.com/wikimedia/wikipedia-kaios.git`
+3. Go to the app source: `cd wikipedia-kaios`
+
+### Build the app
+1. Install app dependencies: `npm install`
+2. Build the app: `npm run build`
+
+### Connect your device
+1. Connect your device to your computer using a USB cable
+2. Enable debug mode on the device by typing: `*#*#33284#*#*`
+3. Check that adb is running and sees your device: `adb devices`
+
+_Steps 2, 3 and 4 need to be redone when you disconnect and reconnect your device or restart your computer._
+
+### Deploy the app to the device
+1. Deploy to device, this may take a few minutes: `npm run deploy`
+
+The Wikipedia app should be running on your device now.
 
 ## To run the Cypress tests
+
 ### Run a test server in one terminal window or tab
 `npm run start`
+
 ### To run headlessly
 `npm test`
+
 ### To open cypress and run inside cypress
 `npm run cypress`
+
+## To keep app updated with latest version
+
+1. Make sure you are in the source directory: `cd ~/code/wikipedia-kaios`
+2. Pull the latest changes: `git pull`
+3. Install latest dependencies: `npm install`
+4. Rebuild the app: `npm run build`
+5. Redeploy the app: `npm run deploy`
+
+---
+
+<p align="center">
+    <img src="https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/1122px-Wikipedia-logo-v2.svg.png" width="200" title="wikipedia-logo">
+</p>
+

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-Phabricator Link : https://phabricator.wikimedia.org/project/view/4301/
+Phabricator Link: https://phabricator.wikimedia.org/project/view/4301/
 
 ### Problem Statement
 


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T245564

Here's a starting point for the development guide, adding to the README:

* Installation requirements
* Instructions to run app on browser and device
* Instructions to keep app updated
* Wikipedia logo at the end

You can [view what it would look like here](https://github.com/wikimedia/wikipedia-kaios/blob/T245564-README-update/README.md).  What do you think? Too much info? Anything we're missing? 

As hinted in the Phabricator task, we don't have to merge this right away if we want to wait until first version is more ready.




