### PR TITLE
Remove font family and variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     />
     <meta name="theme-color" content="rgb(51, 102, 204)" />
     <title>Wikipedia</title>
-    <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
   </head>
 
   <body>

--- a/style/article.less
+++ b/style/article.less
@@ -34,7 +34,6 @@
 			opacity: 0.85;
 
 			.title {
-				font-family: @titleFont;
 				font-size: 22px;
 				line-height: 28px;
 
@@ -42,7 +41,6 @@
 			}
 
 			.desc {
-				font-family: @textFont;
 				font-size: 12px;
 				line-height: 19px;
 				margin-top: 5px;
@@ -87,7 +85,6 @@
 			}
 
 			.article-content {
-				font-family: @textFont;
 				font-size: 14px;
 				line-height: 24.5px;
 

--- a/style/articlelanguage.less
+++ b/style/articlelanguage.less
@@ -5,7 +5,6 @@
 	input {
 		width: calc( 100vw - 20px );
 		font-size: 17px;
-		font-family: @textFont;
 		color: #323232;
 		margin: 5px 10px;
 		border-radius: 2px;

--- a/style/confirmdialog.less
+++ b/style/confirmdialog.less
@@ -1,6 +1,5 @@
 .confirm-dialog {
 	overflow: hidden;
-	font-family: @textFont;
 	font-size: 15px;
 	width: 100%;
 	height: 100%;

--- a/style/error.less
+++ b/style/error.less
@@ -7,7 +7,6 @@
 	flex-direction: column;
 
 	p {
-		font-family: @textFont;
 		font-size: @bigFont;
 		text-align: center;
 	}

--- a/style/footer.less
+++ b/style/footer.less
@@ -1,5 +1,4 @@
 .article-footer {
-	font-family: @textFont;
 	padding: 6px;
 	background-color: #f5f5f5;
 
@@ -33,7 +32,6 @@
 				}
 
 				.info {
-					font-family: @textFont;
 					height: 100%;
 					overflow: hidden;
 					display: flex;

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -4,7 +4,6 @@
 	background-color: #000;
 
 	.header {
-		font-family: @textFont;
 		font-size: 17px;
 		color: #323232;
 		text-overflow: ellipsis;
@@ -36,8 +35,6 @@
 }
 
 .gallery-about {
-	font-family: @textFont;
-
 	.header {
 		font-size: 17px;
 		color: #323232;

--- a/style/language.less
+++ b/style/language.less
@@ -5,7 +5,6 @@
 	input {
 		width: calc( 100vw - 20px );
 		font-size: 17px;
-		font-family: @textFont;
 		color: #323232;
 		margin: 5px 10px;
 		border-radius: 2px;
@@ -24,8 +23,6 @@
 }
 
 .language-message {
-	font-family: @textFont;
-
 	.header {
 		height: @pageHeaderHeight;
 		max-height: @pageHeaderHeight;

--- a/style/listview.less
+++ b/style/listview.less
@@ -5,7 +5,6 @@
 		background-color: #d8d8d8;
 		box-sizing: border-box;
 		padding: 3px 0;
-		font-family: @textFont;
 		font-size: 17px;
 		text-align: center;
 	}
@@ -26,7 +25,6 @@
 			justify-content: space-between;
 
 			.info {
-				font-family: @textFont;
 				height: 100%;
 				overflow: hidden;
 				display: flex;
@@ -76,7 +74,6 @@
 			align-items: center;
 			justify-content: center;
 			padding: 0 10px;
-			font-family: @textFont;
 			font-size: 17px;
 			color: #323232;
 		}

--- a/style/menu.less
+++ b/style/menu.less
@@ -4,7 +4,6 @@
 		bottom: 0;
 
 		.item .info .title {
-			font-family: @textFont;
 			font-size: 17px;
 		}
 

--- a/style/offline.less
+++ b/style/offline.less
@@ -1,7 +1,6 @@
 .offline {
 	background-color: #fc3;
 	color: #323232;
-	font-family: 'Helvetica', serif;
 	font-size: 17px;
 	text-align: center;
 	overflow: hidden;

--- a/style/onboarding.less
+++ b/style/onboarding.less
@@ -1,5 +1,4 @@
 .onboarding {
-	font-family: @textFont;
 	height: calc( 100vh );
 	padding: 0 15px;
 	background-color: #fff;

--- a/style/preview.less
+++ b/style/preview.less
@@ -14,7 +14,6 @@
 		align-items: center;
 
 		.title {
-			font-family: 'Lato', sans-serif;
 			font-weight: bold;
 			font-size: 15px;
 			white-space: nowrap;

--- a/style/radiolistview.less
+++ b/style/radiolistview.less
@@ -5,7 +5,6 @@
 		background-color: #d8d8d8;
 		box-sizing: border-box;
 		padding: 3px 0;
-		font-family: @textFont;
 		font-size: 17px;
 		text-align: center;
 	}
@@ -26,7 +25,6 @@
 			justify-content: space-between;
 
 			.info {
-				font-family: @textFont;
 				height: 100%;
 				overflow: hidden;
 				display: flex;
@@ -77,7 +75,6 @@
 			align-items: center;
 			justify-content: center;
 			padding: 0 10px;
-			font-family: @textFont;
 			font-size: 17px;
 			color: #323232;
 		}

--- a/style/search.less
+++ b/style/search.less
@@ -13,7 +13,6 @@
 	input {
 		width: calc( 100vw - 20px );
 		font-size: 17px;
-		font-family: @textFont;
 		color: #323232;
 		margin: 5px 0 11px 0;
 		border-radius: 2px;
@@ -45,7 +44,6 @@
 
 			.message {
 				font-size: 17px;
-				font-family: @textFont;
 			}
 		}
 	}

--- a/style/settings.less
+++ b/style/settings.less
@@ -4,7 +4,6 @@
 		bottom: @softkeysHeight;
 
 		.item .info .title {
-			font-family: @textFont;
 			font-size: 17px;
 		}
 

--- a/style/softkey.less
+++ b/style/softkey.less
@@ -1,5 +1,4 @@
 .softkey {
-	font-family: @textFont;
 	height: @softkeysHeight;
 	max-height: @softkeysHeight;
 	width: 100%;

--- a/style/textsize.less
+++ b/style/textsize.less
@@ -1,5 +1,4 @@
 .textsize {
-	font-family: @textFont;
 	font-size: 17px;
 
 	.header {

--- a/style/toc.less
+++ b/style/toc.less
@@ -4,7 +4,6 @@
 		bottom: 0;
 
 		.item .info .title {
-			font-family: @textFont;
 			font-size: 17px;
 
 			.subheader2 {

--- a/style/variables.less
+++ b/style/variables.less
@@ -8,9 +8,6 @@
 
 @availableHeight: calc(100vh - @softkeysHeight);
 
-@titleFont: Georgia, sans-serif;
-@textFont: Lato, sans-serif;
-
 @colorLight: #72777d;
 
 @smallFont: 12px;


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T245746

### Problem Statement

Currently, the app download the font family "Lato" from the google apis, and it against WMF user privacy policy

### Solution

Upon checking on the default font styling in several devices, the font works well without assigning any font family, therefore the decision is to use the default font in each device.

### Note

If there is a source pass the policy, that's also not a bad idea to use.