### PR TITLE
Abortable XMLHttpRequest

### DIFF
--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -56,10 +56,10 @@ describe('Article view', () => {
   it('check quick facts opens', () => {
     goToCatArticle()
     articlePage.selectOptionFromActionsMenu('quickfacts')
-    quickFactsPage.table().should('contains.text', 'Various types of domestic cat')
+    quickFactsPage.table().should('contains.text', 'Various types of the domestic cat')
     cy.clickCloseButton()
     articlePage.selectOptionFromArticleMenu('Quick Facts')
-    quickFactsPage.table().should('contains.text', 'Various types of domestic cat')
+    quickFactsPage.table().should('contains.text', 'Various types of the domestic cat')
   })
 
   it('check quick facts link opens', () => {

--- a/src/api/getRandomArticleTitle.js
+++ b/src/api/getRandomArticleTitle.js
@@ -1,10 +1,7 @@
-import { buildPcsUrl } from 'utils'
+import { buildPcsUrl, cachedFetch } from 'utils'
 
 export const getRandomArticleTitle = lang => {
   const url = buildPcsUrl(lang, 'title', 'random')
-  return fetch(url)
-    .then(response => response.json())
-    .then(data => {
-      return data.items[0].title
-    })
+
+  return cachedFetch(url, data => data.items[0].title, true, false)
 }

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -28,5 +28,5 @@ export const search = (lang, term) => {
         imageUrl: p.thumbnail && p.thumbnail.source
       }
     })
-  })
+  }, true)
 }

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'preact/hooks'
+import { useState, useEffect } from 'preact/hooks'
 import { useHistoryState } from 'hooks'
 import { search } from 'api'
 
@@ -6,21 +6,14 @@ export const useSearch = (lang) => {
   const [query, setQuery] = useHistoryState('query', '')
 
   const [searchResults, setSearchResults] = useState()
-  const counter = useRef(0)
 
   useEffect(() => {
     if (query) {
-      const requestId = ++counter.current
       search(lang, query)
-        .then((results) => {
-          // Need to use this trick because the target platform
-          // doesn't have abortable fetch (AbortController).
-          if (requestId === counter.current) {
-            setSearchResults(results)
-          }
+        .then(results => {
+          setSearchResults(results)
         })
     } else {
-      counter.current = 0
       setSearchResults(null)
     }
   }, [lang, query])

--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -2,21 +2,42 @@
 // the last N requests to keep memory usage
 // under control.
 const requestCache = {}
-export const cachedFetch = (url, transformFn) => {
-  if (requestCache[url]) {
+const xhrList = {}
+
+export const cachedFetch = (url, transformFn, abortAllXhr = false, cache = true) => {
+  if (abortAllXhr) {
+    abortAllFetch()
+  }
+
+  if (cache && requestCache[url]) {
     return Promise.resolve(requestCache[url])
   }
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest({ mozSystem: true })
+    const timestamp = (new Date()).valueOf()
+    xhrList[timestamp] = xhr
     xhr.responseType = 'json'
     xhr.open('GET', url)
     xhr.send()
     xhr.addEventListener('load', () => {
-      resolve(requestCache[url] = transformFn(xhr.response))
+      const transformResponse = transformFn(xhr.response)
+      resolve(transformResponse)
+      if (cache) {
+        requestCache[url] = transformResponse
+      }
+      delete xhrList[timestamp]
     })
     xhr.addEventListener('error', () => {
+      delete xhrList[timestamp]
       reject(new Error('XHR Error: ' + xhr.status))
     })
+  })
+}
+
+const abortAllFetch = () => {
+  Object.keys(xhrList).forEach(key => {
+    xhrList[key].abort()
+    delete xhrList[key]
   })
 }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T244021

### Problem Statement

1. Typing in search bar trigger unnecessary fetch event when there is a new search term
1. Press random article multiple times has console error 
1. There isn't abort/cancel event in `cachedFetch`

### Solution

Implement `xhr.abort` in `cachedFetch`

### Note

currently, the random article uses `cachedFetch` with an extra key to make it non-cacheable fetch event,  we can make the fetch event more general to achieve cacheable and non-cacheable event but it requires more depth consideration of how we work with our cache mechanism and ajax (get) event.

Please test the app carefully with this update