### PR TITLE
Add app indicator to user-agent

### DIFF
--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -19,6 +19,7 @@ export const cachedFetch = (url, transformFn, abortAllXhr = false, cache = true)
     xhrList[timestamp] = xhr
     xhr.responseType = 'json'
     xhr.open('GET', url)
+    xhr.setRequestHeader('User-Agent', navigator.userAgent + ' WikipediaApp/1.0')
     xhr.send()
     xhr.addEventListener('load', () => {
       const transformResponse = transformFn(xhr.response)

--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -20,7 +20,7 @@ export const cachedFetch = (url, transformFn, abortAllXhr = false, cache = true)
     xhr.responseType = 'json'
     xhr.open('GET', url)
     // eslint-disable-next-line no-undef
-    xhr.setRequestHeader('User-Agent', navigator.userAgent + ' WikipediaApp/' + APP_VERSION)
+    xhr.setRequestHeader('User-Agent', `WikipediaApp/${APP_VERSION} ${navigator.userAgent}`)
     xhr.send()
     xhr.addEventListener('load', () => {
       const transformResponse = transformFn(xhr.response)

--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -19,7 +19,8 @@ export const cachedFetch = (url, transformFn, abortAllXhr = false, cache = true)
     xhrList[timestamp] = xhr
     xhr.responseType = 'json'
     xhr.open('GET', url)
-    xhr.setRequestHeader('User-Agent', navigator.userAgent + ' WikipediaApp/1.0')
+    // eslint-disable-next-line no-undef
+    xhr.setRequestHeader('User-Agent', navigator.userAgent + ' WikipediaApp/' + APP_VERSION)
     xhr.send()
     xhr.addEventListener('load', () => {
       const transformResponse = transformFn(xhr.response)


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T244547

### Problem Statement

The user-agent has to contain an app identifier in order to count requests to the page content service as page views.

### Solution

Add WikipediaApp/<version> at the beginning of the user agent for all API calls.

### Note
