### PR TITLE
Remove Rate the app from the settings

### DIFF
--- a/cypress/integration/settings-spec.js
+++ b/cypress/integration/settings-spec.js
@@ -17,7 +17,6 @@ const settingsMenuListEnglishText = [enJson['settings-language'],
   enJson['settings-about-wikipedia'],
   enJson['settings-privacy'],
   enJson['settings-term'],
-  enJson['settings-rate'],
   enJson['settings-about-app']]
 const languageSettingsPopupEnglishText = enJson['language-setting-message']
 const languageChangeDutchText = nlJson['language-change']
@@ -26,7 +25,6 @@ const settingsMenuListDutchText = [nlJson['settings-language'],
   nlJson['settings-about-wikipedia'],
   nlJson['settings-privacy'],
   nlJson['settings-term'],
-  nlJson['settings-rate'],
   nlJson['settings-about-app']]
 
 describe('settings page', () => {

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -46,8 +46,8 @@ export const Settings = () => {
     { title: i18n.i18n('settings-about-wikipedia') },
     { title: i18n.i18n('settings-privacy'), link: 'https://foundation.m.wikimedia.org/wiki/Privacy_policy' },
     { title: i18n.i18n('settings-term'), link: `https://foundation.m.wikimedia.org/wiki/Terms_of_Use/${lang}` },
-    { title: i18n.i18n('settings-rate') },
     // @todo will have this soon and don't delete it from the language json
+    // { title: i18n.i18n('settings-rate') },
     // { title: i18n.i18n('settings-help-feedback') },
     { title: i18n.i18n('settings-about-app') }
   ]


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

Currently we are unable to ask user to rate the app

### Solution

Hide it and will release this soon
