### PR TITLE
Update schema version and remove referring_domain implementation

### DIFF
--- a/src/hooks/useTracking.js
+++ b/src/hooks/useTracking.js
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from 'preact/hooks'
 
 const SCHEMA_NAME = 'InukaPageView'
-const SCHEMA_REV = 19739286
+const SCHEMA_REV = 19883738
 const USER_ID_KEY = 'INUKA-PV-U'
 const SESSION_ID_KEY = 'INUKA-PV-S'
 const ONE_HOUR = 3600 * 1000
@@ -105,7 +105,7 @@ export const useTracking = (
           client_type: 'kaios-app',
           // eslint-disable-next-line no-undef
           app_version: APP_VERSION,
-          referring_domain: history.length > 1 ? 'kaios-app' : null,
+          referring_domain: 'kaios-app',
           load_dt: new Date(start).toISOString(),
           page_open_time: Math.round(totalTime),
           page_visible_time: Math.round(totalTime - msPaused),


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T242358

### Problem Statement

The InukaPageView schema was updated to accept app_version but the revision was not updated in the code.

### Solution

Use up to date schema revision.

### Note

Also remove referring_domain implementation that doesn't really work. We'll have to decide what we want to do with it but in the meantime it will not create schema validation errors.