### PR TITLE
Disable webpack bundle size hints

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,9 @@ module.exports = {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist'),
   },
+  performance: {
+    hints: false
+  },
   devServer: {
     publicPath: '/dist/',
     watchOptions: {


### PR DESCRIPTION
### Problem Statement

Webpack bundle size hints are not relevant here since all files are loaded locally on the device. 

### Solution

Disable bundle size hints.

### Note
