### PR TITLE
Fix manifest formatting and zip structure

### DIFF
--- a/scripts/manifest.js
+++ b/scripts/manifest.js
@@ -30,4 +30,4 @@ fs.readdirSync('./i18n').forEach(file => {
 manifest.version = require('../package.json').version
 
 // Send output to stdout
-console.log(manifest)
+console.log(JSON.stringify(manifest, null, 2))

--- a/scripts/zip.sh
+++ b/scripts/zip.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 rm -rf Wikipedia
-mkdir Wikipedia
-
 rm -rf dist
+rm app.zip
+
+mkdir Wikipedia
 
 node scripts/manifest.js > Wikipedia/manifest.webapp
 npm run build
@@ -11,4 +12,5 @@ cp -r dist Wikipedia/
 cp -r images Wikipedia/
 cp index.html Wikipedia/
 
-zip -r app.zip Wikipedia
+cd Wikipedia
+zip -r ../app.zip *


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T240886

### Problem Statement

After testing the app bundle on the KaiStore portal, I found that the manifest needs to be real JSON (duh) and the zip file needs to contain all files at the root.

### Solution

* Format manifest correctly
* Add all files at the root of the zip

### Note
