### PR TITLE
Fixed xhr error handling and error component background

### DIFF
--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -27,7 +27,8 @@ export const cachedFetch = (url, transformFn, abortAllXhr = false, cache = true)
     }
     xhr.send()
     xhr.addEventListener('load', () => {
-      if (xhr.statusText === 'OK') {
+      // Accept all of 2xx and 3xx
+      if (xhr.status >= 200 && xhr.status < 400) {
         const transformResponse = transformFn(xhr.response)
         resolve(transformResponse)
         if (cache) {

--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -27,10 +27,14 @@ export const cachedFetch = (url, transformFn, abortAllXhr = false, cache = true)
     }
     xhr.send()
     xhr.addEventListener('load', () => {
-      const transformResponse = transformFn(xhr.response)
-      resolve(transformResponse)
-      if (cache) {
-        requestCache[url] = transformResponse
+      if (xhr.statusText === 'OK') {
+        const transformResponse = transformFn(xhr.response)
+        resolve(transformResponse)
+        if (cache) {
+          requestCache[url] = transformResponse
+        }
+      } else {
+        reject(new Error('XHR Error: ' + xhr.status))
       }
       delete xhrList[timestamp]
     })

--- a/style/error.less
+++ b/style/error.less
@@ -1,4 +1,5 @@
 .error {
+	background-color: #fff;
 	height: @availableHeight;
 	width: 100vw;
 	display: flex;


### PR DESCRIPTION
### Problem Statement

Since moving from `fetch` to `XMLHttpRequest`, error handling has been partly broken since most error cases call the load callback instead of the error callback.

### Solution

Check the `status` and reject if it's not within [200-400[.

Also set the error component background to white.

### Note
