### PR TITLE
T236318 Add About Wikipedia Page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,3 +16,9 @@ jobs:
             ./scripts/zip.sh
       - store_artifacts:
           path: app.zip
+      - store_artifacts:
+          path: cypress/screenshots
+          destination: screenshots
+      - store_artifacts:
+          path: cypress/videos
+          destination: videos

--- a/cypress.json
+++ b/cypress.json
@@ -6,5 +6,5 @@
     "modifyObstructiveCode": false,
     "baseUrl": "http://127.0.0.1:8080",
     "defaultCommandTimeout": 6000,
-    "video": false
+    "video": true
 }

--- a/cypress/integration/settings-spec.js
+++ b/cypress/integration/settings-spec.js
@@ -112,7 +112,17 @@ describe('settings page', () => {
     cy.getLeftSoftkeyButton().click()
     cy.getLeftSoftkeyButton().click()
     cy.getLeftSoftkeyButton().click()
+    cy.get('.item>.info>.title').first().should('have.text', enJson['settings-language'])
+  })
+
+  it('check exit about wikipedia page', () => {
     languageSettingsPage.selectOptionFromSettings('About Wikipedia')
     aboutWikipediaPage.getHeader().should('have.text', enJson['about-wikipedia-header'])
+    cy.getRightSoftkeyButton().click()
+    aboutWikipediaPage.getImage().should('have.attr', 'src', '/images/onboarding-1.png')
+    cy.getRightSoftkeyButton().click()
+    cy.getCenterSoftkeyButton().should('have.text', enJson['softkey-exit'])
+    cy.getCenterSoftkeyButton().click()
+    cy.get('.item>.info>.title').first().should('have.text', enJson['settings-language'])
   })
 })

--- a/cypress/integration/settings-spec.js
+++ b/cypress/integration/settings-spec.js
@@ -115,13 +115,13 @@ describe('settings page', () => {
     cy.get('.item>.info>.title').first().should('have.text', enJson['settings-language'])
   })
 
-  it('check exit about wikipedia page', () => {
+  it('check close about wikipedia page', () => {
     languageSettingsPage.selectOptionFromSettings('About Wikipedia')
     aboutWikipediaPage.getHeader().should('have.text', enJson['about-wikipedia-header'])
     cy.getRightSoftkeyButton().click()
     aboutWikipediaPage.getImage().should('have.attr', 'src', '/images/onboarding-1.png')
     cy.getRightSoftkeyButton().click()
-    cy.getCenterSoftkeyButton().should('have.text', enJson['softkey-exit'])
+    cy.getCenterSoftkeyButton().should('have.text', enJson['softkey-close'])
     cy.getCenterSoftkeyButton().click()
     cy.get('.item>.info>.title').first().should('have.text', enJson['settings-language'])
   })

--- a/cypress/integration/settings-spec.js
+++ b/cypress/integration/settings-spec.js
@@ -8,12 +8,14 @@ import { SearchPage } from '../page-objects/search-page'
 import { LanguageSettingsPage } from '../page-objects/language-settings-page'
 import { PopupPage } from '../page-objects/popup-page.js'
 import { AboutAppPage } from '../page-objects/about-app-page.js'
+import { AboutWikipediaPage } from '../page-objects/about-wikipedia-page.js'
 
 const searchPage = new SearchPage()
 const settingsPage = new SettingsPage()
 const languageSettingsPage = new LanguageSettingsPage()
 const popupPage = new PopupPage()
 const aboutAppPage = new AboutAppPage()
+const aboutWikipediaPage = new AboutWikipediaPage()
 const settingsMenuListEnglishText = [enJson['settings-language'],
   enJson['settings-textsize'],
   enJson['settings-about-wikipedia'],
@@ -89,5 +91,28 @@ describe('settings page', () => {
     aboutAppPage.getImage().should('have.attr', 'src', '/images/onboarding-0.png')
     aboutAppPage.getVersion().should('have.text', '1.0.0')
     aboutAppPage.getMessage().should('have.text', enJson['about-app-message'])
+  })
+
+  it('check about wikipedia page', () => {
+    languageSettingsPage.selectOptionFromSettings('About Wikipedia')
+    aboutWikipediaPage.getHeader().should('have.text', enJson['about-wikipedia-header'])
+    aboutWikipediaPage.getImage().should('have.attr', 'src', '/images/onboarding-0.png')
+    aboutWikipediaPage.getTitle().should('have.text', enJson['onboarding-0-title'])
+    aboutWikipediaPage.getDescription().should('have.text', enJson['onboarding-0-description'])
+    cy.getRightSoftkeyButton().click()
+
+    aboutWikipediaPage.getImage().should('have.attr', 'src', '/images/onboarding-1.png')
+    aboutWikipediaPage.getTitle().should('have.text', enJson['onboarding-1-title'])
+    aboutWikipediaPage.getDescription().should('have.text', enJson['onboarding-1-description'])
+    cy.getRightSoftkeyButton().click()
+
+    aboutWikipediaPage.getImage().should('have.attr', 'src', '/images/onboarding-2.png')
+    aboutWikipediaPage.getTitle().should('have.text', enJson['onboarding-2-title'])
+    aboutWikipediaPage.getDescription().should('have.text', enJson['onboarding-2-description'])
+    cy.getLeftSoftkeyButton().click()
+    cy.getLeftSoftkeyButton().click()
+    cy.getLeftSoftkeyButton().click()
+    languageSettingsPage.selectOptionFromSettings('About Wikipedia')
+    aboutWikipediaPage.getHeader().should('have.text', enJson['about-wikipedia-header'])
   })
 })

--- a/cypress/page-objects/about-wikipedia-page.js
+++ b/cypress/page-objects/about-wikipedia-page.js
@@ -1,0 +1,17 @@
+export class AboutWikipediaPage {
+  getHeader () {
+    return cy.get('div.about-wikipedia .header')
+  }
+
+  getImage () {
+    return cy.get('div.about-wikipedia .image img')
+  }
+
+  getTitle () {
+    return cy.get('div.about-wikipedia .title')
+  }
+
+  getDescription () {
+    return cy.get('div.about-wikipedia .description')
+  }
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -41,6 +41,7 @@
     "softkey-settings": "Settings",
     "centerkey-select": "Select",
     "softkey-close": "Close",
+    "softkey-exit": "Exit",
     "language-change": "Change app language",
     "language-setting": "Language settings",
     "language-setting-message": "Changing the language here will change the language throughout the app. You can also change the language on each article using the article menu.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -41,7 +41,6 @@
     "softkey-settings": "Settings",
     "centerkey-select": "Select",
     "softkey-close": "Close",
-    "softkey-exit": "Exit",
     "language-change": "Change app language",
     "language-setting": "Language settings",
     "language-setting-message": "Changing the language here will change the language throughout the app. You can also change the language on each article using the article menu.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -20,6 +20,7 @@
     "content-license": "Content is available under <a class=\"external\" rel=\"mw:ExtLink\" href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC BY-SA 3.0</a> unless otherwise noted.",
     "confirm-section": "Go to Section \"$1\"",
     "about-header": "About",
+    "about-wikipedia-header": "About Wikipedia",
     "gallery-description": "Description",
     "gallery-author-license": "Author and license",
     "header-menu": "Article menu",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -20,6 +20,7 @@
 	"content-license": "Text and links for the content license. Shown in the footer",
 	"confirm-section": "Confirm message switch to the selected section page. Shown in the Article page.\n* $1 - Selected section name",
 	"about-header": "The header title of the gallery about page. Shown in the Gallery page",
+	"about-wikipedia-header": "The header title shown in the About Wikipedia page",
 	"gallery-description": "The sub header of the description of the gallery about page. Shown in the Gallery page\n{{Identical|Description}}",
 	"gallery-author-license": "The sub header of the author and license of the gallery about page. Shown in the Gallery page",
 	"header-menu": "The header title of the menu page",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -41,6 +41,7 @@
 	"softkey-settings": "Label of the settings softkey",
 	"centerkey-select": "Label of the center key to choose the selected element. This is used in several contexts when the arrow keys are used to move the focus between visual elements.",
 	"softkey-close": "Label of the close softkey\n{{Identical|Close}}",
+	"softkey-exit": "Label of the exit softkey",
 	"language-change": "Title of the language settings page",
 	"language-setting": "Title of the popup message in the language settings page",
 	"language-setting-message": "Message shown in the popup message in the language settings page",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -41,7 +41,6 @@
 	"softkey-settings": "Label of the settings softkey",
 	"centerkey-select": "Label of the center key to choose the selected element. This is used in several contexts when the arrow keys are used to move the focus between visual elements.",
 	"softkey-close": "Label of the close softkey\n{{Identical|Close}}",
-	"softkey-exit": "Label of the exit softkey",
 	"language-change": "Title of the language settings page",
 	"language-setting": "Title of the popup message in the language settings page",
 	"language-setting-message": "Message shown in the popup message in the language settings page",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2585,6 +2585,51 @@
         "restore-cursor": "^2.0.0"
       }
     },
+    "cli-table3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "cli-truncate": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
@@ -3161,9 +3206,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.1.0.tgz",
-      "integrity": "sha512-FFV8pS9iuriSX4M9rna6awJUhiqozZD1D5z5BprCUJoho1ctbcgpkEUIUnqxli2OwjQqVz07egO+iqoGL+tw7g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.2.0.tgz",
+      "integrity": "sha512-8LdreL91S/QiTCLYLNbIjLL8Ht4fJmu/4HGLxUI20Tc7JSfqEfCmXELrRfuPT0kjosJwJJZacdSji9XSRkPKUw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -3174,6 +3219,7 @@
         "cachedir": "2.3.0",
         "chalk": "2.4.2",
         "check-more-types": "2.24.0",
+        "cli-table3": "0.5.1",
         "commander": "4.1.0",
         "common-tags": "1.8.0",
         "debug": "4.1.1",
@@ -3189,12 +3235,12 @@
         "listr": "0.14.3",
         "lodash": "4.17.15",
         "log-symbols": "3.0.0",
-        "minimist": "1.2.0",
+        "minimist": "1.2.2",
         "moment": "2.24.0",
         "ospath": "1.2.2",
         "pretty-bytes": "5.3.0",
         "ramda": "0.26.1",
-        "request": "2.88.0",
+        "request": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
         "request-progress": "3.0.0",
         "supports-color": "7.1.0",
         "tmp": "0.1.0",
@@ -3239,11 +3285,44 @@
             "chalk": "^2.4.2"
           }
         },
+        "minimist": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.2.tgz",
+          "integrity": "sha512-rIqbOrKb8GJmx/5bc2M0QchhUouMXSpd1RTclXsB41JdL+VtnojfaJR+h7F9k18/4kHUsBFgk80Uk+q569vjPA==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "request": {
+          "version": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
+          "from": "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
         },
         "supports-color": {
           "version": "7.1.0",
@@ -3261,6 +3340,16 @@
           "dev": true,
           "requires": {
             "rimraf": "^2.6.3"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
           }
         }
       }
@@ -9399,6 +9488,7 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -11080,6 +11170,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -11089,7 +11180,8 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-module-resolver": "^3.2.0",
     "css-loader": "^3.2.0",
-    "cypress": "^4.1.0",
+    "cypress": "^4.2.0",
     "cypress-localstorage-commands": "^1.1.6",
     "cypress-wait-until": "^1.6.1",
     "eslint": "^6.6.0",

--- a/src/components/AboutWikipedia.js
+++ b/src/components/AboutWikipedia.js
@@ -13,7 +13,7 @@ export const AboutWikipedia = () => {
   const softkeyConfig = [
     { left: i18n.i18n('softkey-close'), onKeyLeft: () => history.back(), right: i18n.i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
     { left: i18n.i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, right: i18n.i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
-    { left: i18n.i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard }
+    { left: i18n.i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, center: i18n.i18n('softkey-exit'), onKeyCenter: () => history.back() }
   ]
   useSoftkey('AboutWikipedia', softkeyConfig[currentIndex], [currentIndex], true)
 

--- a/src/components/AboutWikipedia.js
+++ b/src/components/AboutWikipedia.js
@@ -1,0 +1,36 @@
+import { h } from 'preact'
+import { useSoftkey, useI18n, useRange } from 'hooks'
+
+export const AboutWikipedia = () => {
+  const i18n = useI18n()
+  const [currentIndex, prevOnboard, nextOnboard] = useRange(0, 3)
+
+  const getImageBackgroundStyle = index => {
+    // only the first onboard image doesn't have background image
+    return index ? { backgroundImage: `url(/images/onboarding-${index}-background.png)` } : {}
+  }
+
+  const softkeyConfig = [
+    { left: i18n.i18n('softkey-close'), onKeyLeft: () => history.back(), right: i18n.i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
+    { left: i18n.i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, right: i18n.i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
+    { left: i18n.i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard }
+  ]
+  useSoftkey('AboutWikipedia', softkeyConfig[currentIndex], [currentIndex], true)
+
+  return (
+    <div class='about-wikipedia'>
+      <div class='header'>{i18n.i18n('about-wikipedia-header')}</div>
+      <div class='body'>
+        <div class='image' style={getImageBackgroundStyle(currentIndex)}>
+          <img src={`/images/onboarding-${currentIndex}.png`} />
+        </div>
+        <div class='title'>
+          {i18n.i18n(`onboarding-${currentIndex}-title`)}
+        </div>
+        <div class='description'>
+          {i18n.i18n(`onboarding-${currentIndex}-description`)}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/AboutWikipedia.js
+++ b/src/components/AboutWikipedia.js
@@ -13,7 +13,7 @@ export const AboutWikipedia = () => {
   const softkeyConfig = [
     { left: i18n.i18n('softkey-close'), onKeyLeft: () => history.back(), right: i18n.i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
     { left: i18n.i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, right: i18n.i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
-    { left: i18n.i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, center: i18n.i18n('softkey-exit'), onKeyCenter: () => history.back() }
+    { left: i18n.i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, center: i18n.i18n('softkey-close'), onKeyCenter: () => history.back() }
   ]
   useSoftkey('AboutWikipedia', softkeyConfig[currentIndex], [currentIndex], true)
 

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -1,7 +1,7 @@
 import { h } from 'preact'
 import { Router, route } from 'preact-router'
 import { createHashHistory } from 'history'
-import { Article, Search, Settings, Language, Onboarding, AboutApp } from 'components'
+import { Article, Search, Settings, Language, Onboarding, AboutApp, AboutWikipedia } from 'components'
 import { onboarding } from 'utils'
 
 export const Routes = ({ onRouteChange }) => {
@@ -19,6 +19,7 @@ export const Routes = ({ onRouteChange }) => {
       <Article path='/article/:lang/:title/:anchor?' />
       <Language path='/language' />
       <AboutApp path='/about-app' />
+      <AboutWikipedia path='/about-wikipedia' />
     </Router>
   )
 }

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -43,7 +43,7 @@ export const Settings = () => {
   const items = [
     { title: i18n.i18n('settings-language'), path: '/language' },
     { title: i18n.i18n('settings-textsize'), action: onTextsizeSelected },
-    { title: i18n.i18n('settings-about-wikipedia') },
+    { title: i18n.i18n('settings-about-wikipedia'), path: '/about-wikipedia' },
     { title: i18n.i18n('settings-privacy'), link: 'https://foundation.m.wikimedia.org/wiki/Privacy_policy' },
     { title: i18n.i18n('settings-term'), link: `https://foundation.m.wikimedia.org/wiki/Terms_of_Use/${lang}` },
     // @todo will have this soon and don't delete it from the language json

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 export * from './AboutApp'
+export * from './AboutWikipedia'
 export * from './App'
 export * from './Article'
 export * from './ArticleFooter'

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -1,0 +1,55 @@
+.about-wikipedia {
+	height: calc( 100vh );
+	background-color: #fff;
+
+	.header {
+		height: @pageHeaderHeight;
+		max-height: @pageHeaderHeight;
+		background-color: #d8d8d8;
+		box-sizing: border-box;
+		padding: 3px 0;
+		font-size: 17px;
+		text-align: center;
+	}
+
+	.body {
+		padding: 0 15px;
+
+		.image {
+			text-align: center;
+			padding: 15px 0;
+			background-position: center center;
+			background-repeat: no-repeat;
+
+			@media ( min-width: 200px ) {
+				background-size: 130px;
+
+				img {
+					width: 74px;
+					height: 74px;
+				}
+			}
+
+			@media ( min-width: 250px ) {
+				background-size: 90px;
+
+				img {
+					width: 50px;
+					height: 50px;
+				}
+			}
+		}
+
+		.title {
+			font-weight: bold;
+			font-size: 22px;
+			line-height: 26px;
+		}
+
+		.description {
+			font-size: 12px;
+			line-height: 17px;
+			margin-top: 5px;
+		}
+	}
+}

--- a/style/style.less
+++ b/style/style.less
@@ -14,6 +14,7 @@
 
 // view style
 @import './aboutapp';
+@import './aboutwikipedia';
 @import './article';
 @import './articlelanguage';
 @import './error';


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T236318

### Note

Reminder that it copies all the image and text from Onboarding page due to the similar content but different UI

Several things can be refactored but can wait

1. Header for the page can be generalized so we can reuse it in component and css
1. Let About App and About Wikipedia open as an popup, so user have the previous settings item selected when Close the about page
1. Reuse the same component for Onboarding and About Wikipedia?

| 1 | 2 | 3 |
| -- | -- | -- |
| ![1](https://user-images.githubusercontent.com/2560096/77183266-5f209700-6ace-11ea-90ab-7d763674a1fc.png) | ![2](https://user-images.githubusercontent.com/2560096/77183260-5def6a00-6ace-11ea-8de5-d087d9a18fda.png) | ![3](https://user-images.githubusercontent.com/2560096/77183254-5b8d1000-6ace-11ea-986e-bb694ec3de95.png) |