### PR TITLE
T248286: Jio2 'About the app' and 'About Wikipedia' layout fix

### DIFF
--- a/style/aboutapp.less
+++ b/style/aboutapp.less
@@ -16,7 +16,7 @@
 		text-align: center;
 
 		@media ( min-width: 250px ) {
-			padding-top: 25px;
+			padding-top: 2px;
 		}
 	}
 

--- a/style/aboutapp.less
+++ b/style/aboutapp.less
@@ -15,7 +15,7 @@
 		padding-top: 30px;
 		text-align: center;
 
-		@media ( min-width: 250px ) {
+		@media @landscape {
 			padding-top: 2px;
 		}
 	}
@@ -41,7 +41,7 @@
 		margin-top: 30px;
 		font-size: 14px;
 
-		@media ( min-width: 250px ) {
+		@media @landscape {
 			margin-top: 0;
 		}
 	}

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -30,7 +30,7 @@
 				}
 			}
 
-			@media ( min-width: 250px ) {
+			@media @landscape {
 				background-size: 90px;
 
 				img {
@@ -45,7 +45,7 @@
 			font-size: 22px;
 			line-height: 26px;
 
-			@media ( min-width: 250px ) {
+			@media @landscape {
 				font-size: 20px;
 				line-height: 22px;
 			}

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -58,7 +58,7 @@
 			margin-top: 5px;
 
 			@media @landscape {
-				line-height: 14px;
+				line-height: 16px;
 				margin-top: 2px;
 				font-size: 14px;
 			}

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -32,6 +32,7 @@
 
 			@media @landscape {
 				background-size: 90px;
+				padding: 15px 0 8px 0;
 
 				img {
 					width: 45px;
@@ -54,7 +55,12 @@
 		.description {
 			font-size: 12px;
 			line-height: 17px;
-			margin-top: 2px;
+			margin-top: 5px;
+
+			@media @landscape {
+				line-height: 14px;
+				margin-top: 2px;
+			}
 		}
 	}
 }

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -60,6 +60,7 @@
 			@media @landscape {
 				line-height: 14px;
 				margin-top: 2px;
+				font-size: 13px;
 			}
 		}
 	}

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -46,7 +46,7 @@
 			line-height: 26px;
 
 			@media @landscape {
-				font-size: 20px;
+				font-size: 17px;
 				line-height: 22px;
 			}
 		}

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -60,7 +60,7 @@
 			@media @landscape {
 				line-height: 16px;
 				margin-top: 2px;
-				font-size: 14px;
+				font-size: 13px;
 			}
 		}
 	}

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -44,6 +44,11 @@
 			font-weight: bold;
 			font-size: 22px;
 			line-height: 26px;
+
+			@media ( min-width: 250px ) {
+				font-size: 20px;
+				line-height: 22px;
+			}
 		}
 
 		.description {

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -34,8 +34,8 @@
 				background-size: 90px;
 
 				img {
-					width: 50px;
-					height: 50px;
+					width: 45px;
+					height: 45px;
 				}
 			}
 		}

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -60,7 +60,6 @@
 			@media @landscape {
 				line-height: 16px;
 				margin-top: 2px;
-				font-size: 13px;
 			}
 		}
 	}

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -54,7 +54,7 @@
 		.description {
 			font-size: 12px;
 			line-height: 17px;
-			margin-top: 5px;
+			margin-top: 2px;
 		}
 	}
 }

--- a/style/aboutwikipedia.less
+++ b/style/aboutwikipedia.less
@@ -60,7 +60,7 @@
 			@media @landscape {
 				line-height: 14px;
 				margin-top: 2px;
-				font-size: 13px;
+				font-size: 14px;
 			}
 		}
 	}

--- a/style/onboarding.less
+++ b/style/onboarding.less
@@ -18,7 +18,7 @@
 			}
 		}
 
-		@media ( min-width: 250px ) {
+		@media @landscape {
 			background-size: 100px;
 
 			img {

--- a/style/variables.less
+++ b/style/variables.less
@@ -15,4 +15,5 @@
 
 @data-selected-selector: &[ data-selected='true'];
 
+// Landscape size is 320x240, this supports Jio2 devices
 @landscape: (min-width: 250px);

--- a/style/variables.less
+++ b/style/variables.less
@@ -14,3 +14,5 @@
 @bigFont: 17px;
 
 @data-selected-selector: &[ data-selected='true'];
+
+@landscape: (min-width: 250px);


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T248286

### Problem Statement

'About the app' and 'About Wikipedia' pages are not rendering correctly in Jio2 devices.

### Solution

Minor CSS adjustments 

### Note

~To be tested on Jio2 device by someone who has one, I have requested this on the Phabricator thread. Let's not merge until it's confirmed it looks good on device~

Tested by Sudhanshu on Jio2 device now

