### PR TITLE
Fix multiple beacon sent when closing the window

### DIFF
--- a/src/hooks/useTracking.js
+++ b/src/hooks/useTracking.js
@@ -125,6 +125,7 @@ export const useTracking = (
       sendEvent(event)
 
       document.removeEventListener('visibilitychange', onVisibilityChanged)
+      window.removeEventListener('pagehide', sendBeacon)
     }
     window.addEventListener('pagehide', sendBeacon)
 


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T248757

### Problem Statement

When closing/refreshing the window, there are multiple beacons sent

### Solution

remove pagehide event when one is being sent

### Note

This is part of the ticket {T248757}