### PR TITLE
T248381: about pages

### DIFF
--- a/src/components/AboutApp.js
+++ b/src/components/AboutApp.js
@@ -2,14 +2,14 @@ import { h } from 'preact'
 import { useI18n, useSoftkey } from 'hooks'
 import { appVersion } from 'utils'
 
-export const AboutApp = () => {
+export const AboutApp = ({ close }) => {
   const i18n = useI18n()
 
   useSoftkey('AboutApp', {
     right: i18n('softkey-read-more'),
     onKeyRight: () => window.open('https://wikimediafoundation.org/'),
     left: i18n('softkey-close'),
-    onKeyLeft: () => history.back()
+    onKeyLeft: close
   }, [])
 
   return (

--- a/src/components/AboutWikipedia.js
+++ b/src/components/AboutWikipedia.js
@@ -1,7 +1,7 @@
 import { h } from 'preact'
 import { useSoftkey, useI18n, useRange } from 'hooks'
 
-export const AboutWikipedia = () => {
+export const AboutWikipedia = ({ close }) => {
   const i18n = useI18n()
   const [currentIndex, prevOnboard, nextOnboard] = useRange(0, 3)
 
@@ -11,9 +11,9 @@ export const AboutWikipedia = () => {
   }
 
   const softkeyConfig = [
-    { left: i18n('softkey-close'), onKeyLeft: () => history.back(), right: i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
+    { left: i18n('softkey-close'), onKeyLeft: close, right: i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
     { left: i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, right: i18n('softkey-next'), onKeyRight: nextOnboard, onKeyArrowRight: nextOnboard },
-    { left: i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, center: i18n('softkey-close'), onKeyCenter: () => history.back() }
+    { left: i18n('softkey-back'), onKeyLeft: prevOnboard, onKeyArrowLeft: prevOnboard, center: i18n('softkey-close'), onKeyCenter: close }
   ]
   useSoftkey('AboutWikipedia', softkeyConfig[currentIndex], [currentIndex], true)
 

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -1,7 +1,7 @@
 import { h } from 'preact'
 import { Router, route } from 'preact-router'
 import { createHashHistory } from 'history'
-import { Article, Search, Settings, Language, Onboarding, AboutApp, AboutWikipedia } from 'components'
+import { Article, Search, Settings, Language, Onboarding, AboutWikipedia } from 'components'
 import { onboarding } from 'utils'
 
 export const Routes = ({ onRouteChange }) => {
@@ -18,7 +18,6 @@ export const Routes = ({ onRouteChange }) => {
       <Settings path='/settings' />
       <Article path='/article/:lang/:title/:anchor?' />
       <Language path='/language' />
-      <AboutApp path='/about-app' />
       <AboutWikipedia path='/about-wikipedia' />
     </Router>
   )

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -1,7 +1,7 @@
 import { h } from 'preact'
 import { Router, route } from 'preact-router'
 import { createHashHistory } from 'history'
-import { Article, Search, Settings, Language, Onboarding, AboutWikipedia } from 'components'
+import { Article, Search, Settings, Language, Onboarding } from 'components'
 import { onboarding } from 'utils'
 
 export const Routes = ({ onRouteChange }) => {
@@ -18,7 +18,6 @@ export const Routes = ({ onRouteChange }) => {
       <Settings path='/settings' />
       <Article path='/article/:lang/:title/:anchor?' />
       <Language path='/language' />
-      <AboutWikipedia path='/about-wikipedia' />
     </Router>
   )
 }

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -2,7 +2,7 @@ import { h } from 'preact'
 import { route } from 'preact-router'
 import { useRef, useEffect } from 'preact/hooks'
 import { useNavigation, useI18n, useSoftkey, usePopup } from 'hooks'
-import { ListView, TextSize } from 'components'
+import { ListView, TextSize, AboutApp } from 'components'
 import { getAppLanguage } from 'utils'
 
 export const Settings = () => {
@@ -28,6 +28,11 @@ export const Settings = () => {
     showTextSize()
   }
 
+  const onAboutAppSelected = () => {
+    const [showAboutApp] = usePopup(AboutApp, { mode: 'fullscreen' })
+    showAboutApp()
+  }
+
   useSoftkey('Settings', {
     left: i18n('softkey-close'),
     onKeyLeft: () => history.back(),
@@ -50,7 +55,7 @@ export const Settings = () => {
     // @todo will have this soon and don't delete it from the language json
     // { title: i18n('settings-rate') },
     // { title: i18n('settings-help-feedback') },
-    { title: i18n('settings-about-app'), path: '/about-app' }
+    { title: i18n('settings-about-app'), action: onAboutAppSelected }
   ]
 
   return <div class='settings'>

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -2,7 +2,7 @@ import { h } from 'preact'
 import { route } from 'preact-router'
 import { useRef, useEffect } from 'preact/hooks'
 import { useNavigation, useI18n, useSoftkey, usePopup } from 'hooks'
-import { ListView, TextSize, AboutApp } from 'components'
+import { ListView, TextSize, AboutApp, AboutWikipedia } from 'components'
 import { getAppLanguage } from 'utils'
 
 export const Settings = () => {
@@ -33,6 +33,11 @@ export const Settings = () => {
     showAboutApp()
   }
 
+  const onAboutWikipediaSelected = () => {
+    const [showAboutWikipedia] = usePopup(AboutWikipedia, { mode: 'fullscreen' })
+    showAboutWikipedia()
+  }
+
   useSoftkey('Settings', {
     left: i18n('softkey-close'),
     onKeyLeft: () => history.back(),
@@ -49,7 +54,7 @@ export const Settings = () => {
   const items = [
     { title: i18n('settings-language'), path: '/language' },
     { title: i18n('settings-textsize'), action: onTextsizeSelected },
-    { title: i18n('settings-about-wikipedia'), path: '/about-wikipedia' },
+    { title: i18n('settings-about-wikipedia'), action: onAboutWikipediaSelected },
     { title: i18n('settings-privacy'), link: 'https://foundation.m.wikimedia.org/wiki/Privacy_policy' },
     { title: i18n('settings-term'), link: `https://foundation.m.wikimedia.org/wiki/Terms_of_Use/${lang}` },
     // @todo will have this soon and don't delete it from the language json

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -9,6 +9,10 @@ export const Settings = () => {
   const containerRef = useRef()
   const i18n = useI18n()
   const lang = getAppLanguage()
+  const [showTextSize] = usePopup(TextSize)
+  const [showAboutApp] = usePopup(AboutApp, { mode: 'fullscreen' })
+  const [showAboutWikipedia] = usePopup(AboutWikipedia, { mode: 'fullscreen' })
+
   const onKeyCenter = () => {
     const { index } = getCurrent()
     const item = items[index]
@@ -24,17 +28,14 @@ export const Settings = () => {
   }
 
   const onTextsizeSelected = () => {
-    const [showTextSize] = usePopup(TextSize)
     showTextSize()
   }
 
   const onAboutAppSelected = () => {
-    const [showAboutApp] = usePopup(AboutApp, { mode: 'fullscreen' })
     showAboutApp()
   }
 
   const onAboutWikipediaSelected = () => {
-    const [showAboutWikipedia] = usePopup(AboutWikipedia, { mode: 'fullscreen' })
     showAboutWikipedia()
   }
 

--- a/src/reducers/SoftkeyReducer.js
+++ b/src/reducers/SoftkeyReducer.js
@@ -5,7 +5,9 @@ export const SoftkeyReducer = (state, action) => {
     case 'set':
       return { ...state, current: { ...state.current, ...action.config } }
     case 'replace':
-      return { ...state, current: { ...action.config } }
+      // eslint-disable-next-line no-case-declarations
+      const { name, counter } = state.current
+      return { ...state, current: { name, counter, ...action.config } }
     case 'push':
       stack = state.stack || []
       current = state.current


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T248381

### Problem statement

When you close the `AboutApp` and `AboutWikipedia` screens from `Settings` menu, the navigation position is not being kept

### Solution

Render both `AboutApp` and `AboutWikipedia` screens as popups (instead of having a specific route for it)
