### PR TITLE
T248285: allow letter 's', 'd' and 'f' to change text size in Jio2 device

### DIFF
--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -112,6 +112,28 @@ describe('Article view', () => {
     articlePage.getArticleText().should('have.attr', 'style', 'font-size: 20px;')
   })
 
+  it('check text size change with letters', () => {
+    goToCatArticle()
+    articlePage.selectOptionFromArticleMenu('Text size')
+    popupPage.getHeader().should('have.text', enJson['header-textsize'])
+    popupPage.getContent().should('have.text', enJson['textsize-decrease'] + enJson['textsize-default'] + enJson['textsize-increase'])
+    cy.clickCloseButton()
+    cy.downArrow()
+    cy.downArrow()
+    cy.downArrow()
+    articlePage.getArticleText().should('have.attr', 'style', 'font-size: 16px;')
+    cy.get('body').type('s')
+    cy.get('body').type('s')
+    articlePage.getArticleText().should('have.attr', 'style', 'font-size: 14px;')
+    cy.get('body').type('d')
+    articlePage.getArticleText().should('have.attr', 'style', 'font-size: 16px;')
+    cy.get('body').type('f')
+    cy.get('body').type('f')
+    cy.get('body').type('f')
+    cy.get('body').type('f')
+    articlePage.getArticleText().should('have.attr', 'style', 'font-size: 20px;')
+  })
+
   it('check text size remains after switching sections', () => {
     goToCatArticle()
     articlePage.getArticleText().should('have.attr', 'style', 'font-size: 16px;')

--- a/src/components/Softkey.js
+++ b/src/components/Softkey.js
@@ -19,7 +19,10 @@ export const Softkey = ({
   onKeyArrowRight,
   onKeyboard4,
   onKeyboard5,
-  onKeyboard6
+  onKeyboard6,
+  onKeyS,
+  onKeyD,
+  onKeyF
 }) => {
   const handlersRef = useRef()
   handlersRef.current = {
@@ -32,7 +35,10 @@ export const Softkey = ({
     ArrowRight: onKeyArrowRight,
     4: onKeyboard4,
     5: onKeyboard5,
-    6: onKeyboard6
+    6: onKeyboard6,
+    s: onKeyS,
+    d: onKeyD,
+    f: onKeyF
   }
   const onKeyDown = (e) => {
     const key = e.key.toString()

--- a/src/utils/articleTextSize.js
+++ b/src/utils/articleTextSize.js
@@ -53,11 +53,14 @@ const init = () => {
 
 const getSoftkeyEffect = (onAdjust = () => {}) => {
   const onKeyboard4 = () => { adjust(-1); onAdjust(get()) }
+  const onKeyS = () => { adjust(-1); onAdjust(get()) }
   const onKeyboard5 = () => { reset(); onAdjust(get()) }
+  const onKeyD = () => { reset(); onAdjust(get()) }
   const onKeyboard6 = () => { adjust(1); onAdjust(get()) }
+  const onKeyF = () => { adjust(1); onAdjust(get()) }
 
   return {
-    onKeyboard4, onKeyboard5, onKeyboard6
+    onKeyboard4, onKeyboard5, onKeyboard6, onKeyS, onKeyD, onKeyF
   }
 }
 


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T248285

### Problem Statement

Because of the different keyboard in Jio2 devices (QWERTY), changing text size with 4, 5 and 6 is not intuitive.

### Solution

Adding the following handlers for three letters to also have the same respective behavior:

* 's' to decrease size like 4
* 'd' to set default like 5
* 'f' to increase size like 6

### Note

I was able to test on browser and banana phone only. On browser, both s/d/f letter and 4/5/6 numbers are working, on banana phone the numbers work as usual and the letters don't (as expected). 

We need to test this on Jio2 device now.

Note that handlers are case sensitive. At the moment I don't know if pressing said letters on Jio2 keyboard will give you lowercase or uppercase, I'm assuming lowercase and left it as such in the code. If it's not working on Jio2, this could be the reason why and we can try with uppercase handlers. We could also include both lowercase and uppercase, but I don't think that should be necessary. 
