### PR TITLE
Set referer

### DIFF
--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -23,6 +23,7 @@ export const cachedFetch = (url, transformFn, abortAllXhr = false, cache = true)
     xhr.open('GET', url)
     if (isProd()) {
       xhr.setRequestHeader('User-Agent', `WikipediaApp/${appVersion()} ${navigator.userAgent}`)
+      xhr.setRequestHeader('Referer', 'https://www.wikipedia.org')
     }
     xhr.send()
     xhr.addEventListener('load', () => {


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T249216

### Problem Statement

KaiOS app API calls appear to have no referer and that throws off the analysis.

### Solution

Force a dummy referer so it's clear that the page views are internally referred (from the app, to the app)

### Note
