### PR TITLE
Link to mobile site for media

### DIFF
--- a/src/api/getArticleMediaInfo.js
+++ b/src/api/getArticleMediaInfo.js
@@ -30,9 +30,13 @@ export const getArticleMediaInfo = (lang, title, fromCommon) => {
       author,
       description,
       license: LicenseShortName && LicenseShortName.value,
-      filePage: imageInfo[0].descriptionshorturl
+      filePage: convertUrlToMobile(imageInfo[0].descriptionshorturl)
     }
   })
+}
+
+const convertUrlToMobile = url => {
+  return url.replace(/https:\/\/(.*?)\./, subDomain => subDomain + 'm.')
 }
 
 const strip = html => {


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T249468

### Problem Statement

Selecting "more info" about an image opens the desktop version of wikipedia or common and it doesn't seem to correctly detect KaiOS as mobile.

### Solution

Force the mobile domain on those URLs.

### Note
