### PR TITLE
T249710 Allow app language to always match device language

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,18 +9,13 @@ import { App } from 'components'
 
 import '../style/style.less'
 
-let banana
-
 if (checkHasDeviceLanguageChanged()) {
   setDeviceLanguage()
-  const lang = getDeviceLanguage()
-  setAppLanguage(lang)
-  banana = new Banana(lang)
-} else {
-  const lang = getAppLanguage()
-  banana = new Banana(lang)
+  setAppLanguage(getDeviceLanguage())
 }
 
+const lang = getAppLanguage()
+const banana = new Banana(lang)
 banana.load(loadAllLanguagesMessages())
 
 render(<App i18n={banana} />, document.querySelector('.root'))

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,25 @@
 import 'preact/debug'
 import { h, render } from 'preact'
 import Banana from 'banana-i18n'
-import { setAppLanguage, getAppLanguage, loadAllLanguagesMessages } from 'utils'
+import {
+  setAppLanguage, getAppLanguage, setDeviceLanguage, getDeviceLanguage,
+  checkHasDeviceLanguageChanged, loadAllLanguagesMessages
+} from 'utils'
 import { App } from 'components'
 
 import '../style/style.less'
 
-const lang = getAppLanguage() || navigator.language.substr(0, 2)
-setAppLanguage(lang)
-const banana = new Banana(lang)
+let banana
+
+if (checkHasDeviceLanguageChanged()) {
+  setDeviceLanguage()
+  const lang = getDeviceLanguage()
+  setAppLanguage(lang)
+  banana = new Banana(lang)
+} else {
+  const lang = getAppLanguage()
+  banana = new Banana(lang)
+}
 
 banana.load(loadAllLanguagesMessages())
 

--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1488,9 +1488,7 @@ export const getAppLanguage = () => {
 }
 
 export const setDeviceLanguage = () => {
-  const navigatorLang = navigator.language
-  const lang = navigatorLang.substr(0, navigatorLang.indexOf('-'))
-  localStorage.setItem('language-device', lang)
+  localStorage.setItem('language-device', getCurrentDeviceLanguage())
 }
 
 export const getDeviceLanguage = () => {
@@ -1498,8 +1496,10 @@ export const getDeviceLanguage = () => {
 }
 
 export const checkHasDeviceLanguageChanged = () => {
-  const navigatorLang = navigator.language
-  const lang = navigatorLang.substr(0, navigatorLang.indexOf('-'))
+  return getCurrentDeviceLanguage() !== localStorage.getItem('language-device')
+}
 
-  return lang !== localStorage.getItem('language-device')
+const getCurrentDeviceLanguage = () => {
+  const navigatorLang = navigator.language
+  return navigatorLang.substr(0, navigatorLang.indexOf('-'))
 }

--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1486,3 +1486,20 @@ export const setAppLanguage = lang => {
 export const getAppLanguage = () => {
   return localStorage.getItem('language-app')
 }
+
+export const setDeviceLanguage = () => {
+  const navigatorLang = navigator.language
+  const lang = navigatorLang.substr(0, navigatorLang.indexOf('-'))
+  localStorage.setItem('language-device', lang)
+}
+
+export const getDeviceLanguage = () => {
+  return localStorage.getItem('language-device')
+}
+
+export const checkHasDeviceLanguageChanged = () => {
+  const navigatorLang = navigator.language
+  const lang = navigatorLang.substr(0, navigatorLang.indexOf('-'))
+
+  return lang !== localStorage.getItem('language-device')
+}


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T249710

### Problem Statement

When user changes the device language, the app language doesn't change

### Solution

Having two language storage for device and app language, always check whether the device language has changed before rendering the app

### Note

_code looks ugly ☹️ , do you have any idea?_