### PR TITLE
T250253: update useNavigation to support stacked popups

### DIFF
--- a/src/components/ArticleLanguage.js
+++ b/src/components/ArticleLanguage.js
@@ -6,6 +6,7 @@ import { goto } from 'utils'
 
 export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
   const containerRef = useRef()
+  const listRef = useRef()
   const i18n = useI18n()
   const [articleLang, setArticleLang] = useState(lang)
   const [items, query, setQuery, numOfLanglink] = useSearchArticleLanguage(articleLang, title)
@@ -14,7 +15,7 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
     return <Loading message={i18n('article-language-loading-message')} onClose={close} />
   }
 
-  const [, setNavigation, getCurrent] = useNavigation('ArticleLanguage', containerRef, 'y')
+  const [, setNavigation, getCurrent] = useNavigation('ArticleLanguage', containerRef, listRef, 'y')
   const onKeyCenter = () => {
     const { index } = getCurrent()
     if (index > 0) {
@@ -55,8 +56,8 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
     setNavigation(0)
   }, [])
 
-  return <div class='articlelanguage'>
+  return <div class='articlelanguage' ref={containerRef}>
     <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable />
-    <RadioListView header={i18n('article-language-available', numOfLanglink)} items={items} containerRef={containerRef} empty={i18n('no-result-found')} />
+    <RadioListView header={i18n('article-language-available', numOfLanglink)} items={items} containerRef={listRef} empty={i18n('no-result-found')} />
   </div>
 }

--- a/src/components/ArticleLanguage.js
+++ b/src/components/ArticleLanguage.js
@@ -14,7 +14,7 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
     return <Loading message={i18n('article-language-loading-message')} onClose={close} />
   }
 
-  const [, setNavigation, getCurrent] = useNavigation('ArticleLanguage', containerRef, 'y', '[data-selectable-radio-list]')
+  const [, setNavigation, getCurrent] = useNavigation('ArticleLanguage', containerRef, 'y')
   const onKeyCenter = () => {
     const { index } = getCurrent()
     if (index > 0) {
@@ -56,7 +56,7 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
   }, [])
 
   return <div class='articlelanguage'>
-    <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable-radio-list />
+    <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable />
     <RadioListView header={i18n('article-language-available', numOfLanglink)} items={items} containerRef={containerRef} empty={i18n('no-result-found')} />
   </div>
 }

--- a/src/components/ArticleLanguage.js
+++ b/src/components/ArticleLanguage.js
@@ -14,7 +14,7 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
     return <Loading message={i18n('article-language-loading-message')} onClose={close} />
   }
 
-  const [, setNavigation, getCurrent] = useNavigation('ArticleLanguage', containerRef, 'y')
+  const [, setNavigation, getCurrent] = useNavigation('ArticleLanguage', containerRef, 'y', '[data-selectable-radio-list]')
   const onKeyCenter = () => {
     const { index } = getCurrent()
     if (index > 0) {
@@ -56,7 +56,7 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
   }, [])
 
   return <div class='articlelanguage'>
-    <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable />
+    <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable-radio-list />
     <RadioListView header={i18n('article-language-available', numOfLanglink)} items={items} containerRef={containerRef} empty={i18n('no-result-found')} />
   </div>
 }

--- a/src/components/ArticleMenu.js
+++ b/src/components/ArticleMenu.js
@@ -11,6 +11,7 @@ export const ArticleMenu = ({
   hasLanguages, hasInfobox, hasGallery
 }) => {
   const containerRef = useRef()
+  const listRef = useRef()
   const i18n = useI18n()
   const onKeyCenter = () => {
     const { index } = getCurrent()
@@ -30,7 +31,7 @@ export const ArticleMenu = ({
     onKeyBackspace: close
   })
 
-  const [, setNavigation, getCurrent] = useNavigation('Menu', containerRef, 'y')
+  const [, setNavigation, getCurrent] = useNavigation('Menu', containerRef, listRef, 'y')
 
   const onSearchSelected = () => {
     close()
@@ -91,11 +92,11 @@ export const ArticleMenu = ({
     }
   ]
 
-  return <div class='menu'>
+  return <div class='menu' ref={containerRef}>
     <ListView
       header={i18n('header-menu')}
       items={items.filter(item => item.enabled)}
-      containerRef={containerRef}
+      containerRef={listRef}
     />
   </div>
 }

--- a/src/components/ArticleToc.js
+++ b/src/components/ArticleToc.js
@@ -5,9 +5,10 @@ import { ListView } from 'components'
 
 export const ArticleToc = ({ items, currentAnchor, onSelectItem, close, closeAll }) => {
   const containerRef = useRef()
+  const listRef = useRef()
   const i18n = useI18n()
   const listItems = parseTocItems(items)
-  const [, setNavigation, getCurrent] = useNavigation('ArticleToc', containerRef, 'y')
+  const [, setNavigation, getCurrent] = useNavigation('ArticleToc', containerRef, listRef, 'y')
   const onKeyCenter = () => {
     const { index } = getCurrent()
     const item = listItems[index]
@@ -29,8 +30,8 @@ export const ArticleToc = ({ items, currentAnchor, onSelectItem, close, closeAll
     setNavigation(listItems.findIndex(item => item.anchor === currentAnchor))
   }, [])
 
-  return <div class='toc'>
-    <ListView header={i18n('header-sections')} items={listItems} containerRef={containerRef} />
+  return <div class='toc' ref={containerRef}>
+    <ListView header={i18n('header-sections')} items={listItems} containerRef={listRef} />
   </div>
 }
 

--- a/src/components/ArticleToc.js
+++ b/src/components/ArticleToc.js
@@ -14,7 +14,7 @@ export const ArticleToc = ({ items, currentAnchor, onSelectItem, close, closeAll
 
     if (item && item.title) {
       onSelectItem(item)
-      close()
+      closeAll()
     }
   }
   useSoftkey('ArticleToc', {

--- a/src/components/Language.js
+++ b/src/components/Language.js
@@ -10,7 +10,7 @@ export const Language = () => {
   const [lang, setLang] = useState(getAppLanguage())
   const [items, query, setQuery] = useSearchLanguage(lang)
   const [showLanguagePopup] = usePopup(LanguagePopup)
-  const [, setNavigation, getCurrent] = useNavigation('Language', containerRef, 'y', '[data-selectable-radio-list]')
+  const [, setNavigation, getCurrent] = useNavigation('Language', containerRef, 'y')
 
   const onKeyCenter = () => {
     const { index } = getCurrent()
@@ -48,7 +48,7 @@ export const Language = () => {
   }, [])
 
   return <div class='language'>
-    <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable-radio-list />
+    <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable />
     <RadioListView header={i18n('language-change')} items={items} containerRef={containerRef} empty={i18n('no-result-found')} />
   </div>
 }

--- a/src/components/Language.js
+++ b/src/components/Language.js
@@ -10,7 +10,7 @@ export const Language = () => {
   const [lang, setLang] = useState(getAppLanguage())
   const [items, query, setQuery] = useSearchLanguage(lang)
   const [showLanguagePopup] = usePopup(LanguagePopup)
-  const [, setNavigation, getCurrent] = useNavigation('Language', containerRef, 'y')
+  const [, setNavigation, getCurrent] = useNavigation('Language', containerRef, 'y', '[data-selectable-radio-list]')
 
   const onKeyCenter = () => {
     const { index } = getCurrent()
@@ -48,7 +48,7 @@ export const Language = () => {
   }, [])
 
   return <div class='language'>
-    <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable />
+    <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable-radio-list />
     <RadioListView header={i18n('language-change')} items={items} containerRef={containerRef} empty={i18n('no-result-found')} />
   </div>
 }

--- a/src/components/Language.js
+++ b/src/components/Language.js
@@ -6,11 +6,13 @@ import { setAppLanguage, getAppLanguage } from 'utils'
 
 export const Language = () => {
   const containerRef = useRef()
+  const listRef = useRef()
+
   const i18n = useI18n()
   const [lang, setLang] = useState(getAppLanguage())
   const [items, query, setQuery] = useSearchLanguage(lang)
   const [showLanguagePopup] = usePopup(LanguagePopup)
-  const [, setNavigation, getCurrent] = useNavigation('Language', containerRef, 'y')
+  const [, setNavigation, getCurrent] = useNavigation('Language', containerRef, listRef, 'y')
 
   const onKeyCenter = () => {
     const { index } = getCurrent()
@@ -47,9 +49,9 @@ export const Language = () => {
     showLanguagePopup({ i18n })
   }, [])
 
-  return <div class='language'>
+  return <div class='language' ref={containerRef}>
     <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable />
-    <RadioListView header={i18n('language-change')} items={items} containerRef={containerRef} empty={i18n('no-result-found')} />
+    <RadioListView header={i18n('language-change')} items={items} containerRef={listRef} empty={i18n('no-result-found')} />
   </div>
 }
 

--- a/src/components/RadioListView.js
+++ b/src/components/RadioListView.js
@@ -7,7 +7,7 @@ export const RadioListView = ({ items = [], header, containerRef, empty }) => {
       <div class='list' ref={containerRef}>
         {
           items.length ? items.map(item => (
-            <div class='item' data-selectable-radio-list data-title={item.title} data-selected-key={item.title} key={item.title}>
+            <div class='item' data-selectable data-title={item.title} data-selected-key={item.title} key={item.title}>
               <div class='info'>
                 <div class='title'>{item.title}</div>
                 { item.description && <div class='description'>{item.description}</div> }

--- a/src/components/RadioListView.js
+++ b/src/components/RadioListView.js
@@ -7,7 +7,7 @@ export const RadioListView = ({ items = [], header, containerRef, empty }) => {
       <div class='list' ref={containerRef}>
         {
           items.length ? items.map(item => (
-            <div class='item' data-selectable data-title={item.title} data-selected-key={item.title} key={item.title}>
+            <div class='item' data-selectable-radio-list data-title={item.title} data-selected-key={item.title} key={item.title}>
               <div class='info'>
                 <div class='title'>{item.title}</div>
                 { item.description && <div class='description'>{item.description}</div> }

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -22,8 +22,9 @@ const SearchOfflinePanel = () => {
 export const Search = () => {
   const containerRef = useRef()
   const inputRef = useRef()
+  const listRef = useRef()
   const i18n = useI18n()
-  const [current, setNavigation, getCurrent] = useNavigation('Search', containerRef, 'y')
+  const [current, setNavigation, getCurrent] = useNavigation('Search', containerRef, listRef, 'y')
   const lang = getAppLanguage()
   const [query, setQuery, searchResults] = useSearch(lang)
   const isOnline = useOnlineStatus(online => {
@@ -59,10 +60,10 @@ export const Search = () => {
   }, [])
 
   return (
-    <div class='search'>
+    <div class='search' ref={containerRef}>
       <img class='double-u' src='images/w.svg' style={{ display: ((searchResults || !isOnline) ? 'none' : 'block') }} />
       <input ref={inputRef} type='text' placeholder={i18n('search-placeholder')} value={query} onInput={onInput} data-selectable />
-      { (isOnline && searchResults) && <ListView header={i18n('header-search')} items={searchResults} containerRef={containerRef} empty={i18n('no-result-found')} /> }
+      { (isOnline && searchResults) && <ListView header={i18n('header-search')} items={searchResults} containerRef={listRef} empty={i18n('no-result-found')} /> }
       { !isOnline && <SearchOfflinePanel /> }
     </div>
   )

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -7,6 +7,7 @@ import { getAppLanguage } from 'utils'
 
 export const Settings = () => {
   const containerRef = useRef()
+  const listRef = useRef()
   const i18n = useI18n()
   const lang = getAppLanguage()
   const [showTextSize] = usePopup(TextSize)
@@ -47,7 +48,7 @@ export const Settings = () => {
     onKeyBackspace: () => history.back()
   })
 
-  const [, setNavigation, getCurrent] = useNavigation('Settings', containerRef, 'y')
+  const [, setNavigation, getCurrent] = useNavigation('Settings', containerRef, listRef, 'y')
 
   useEffect(() => {
     setNavigation(0)
@@ -65,11 +66,11 @@ export const Settings = () => {
     { title: i18n('settings-about-app'), action: onAboutAppSelected }
   ]
 
-  return <div class='settings'>
+  return <div class='settings' ref={containerRef}>
     <ListView
       header={i18n('header-settings')}
       items={items}
-      containerRef={containerRef}
+      containerRef={listRef}
     />
   </div>
 }

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -4,19 +4,18 @@ import { useSoftkey } from 'hooks'
 export const useNavigation = (origin, containerRef, axis, elementsSelector = '[data-selectable]') => {
   const [current, setCurrent] = useState({ type: null, index: 0, key: null })
 
-  const getAllElements = () => document.querySelectorAll(elementsSelector)
+  const getAllElements = () => {
+    if (containerRef.current === undefined) {
+      return document.querySelectorAll(elementsSelector)
+    }
+
+    const grandparentContainer = containerRef.current.parentNode.parentNode
+    return grandparentContainer.querySelectorAll(elementsSelector)
+  }
 
   const getSelectedElement = () => {
-    const allNavSelectedTrue = document.querySelectorAll('[nav-selected=true]')
-    const currentSelector = elementsSelector.slice(1, -1)
-    let selectedElement
-    allNavSelectedTrue.forEach(element => {
-      if (element.getAttribute(currentSelector)) {
-        selectedElement = element
-      }
-    })
-
-    return selectedElement
+    const grandparentContainer = containerRef.current.parentNode.parentNode
+    return grandparentContainer.querySelector('[nav-selected=true]')
   }
 
   const getTheIndexOfTheSelectedElement = () => {

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -7,7 +7,16 @@ export const useNavigation = (origin, containerRef, axis, elementsSelector = '[d
   const getAllElements = () => document.querySelectorAll(elementsSelector)
 
   const getSelectedElement = () => {
-    return document.querySelector('[nav-selected=true]')
+    const allNavSelectedTrue = document.querySelectorAll('[nav-selected=true]')
+    const currentSelector = elementsSelector.slice(1, -1)
+    let selectedElement
+    allNavSelectedTrue.forEach(element => {
+      if (element.getAttribute(currentSelector)) {
+        selectedElement = element
+      }
+    })
+
+    return selectedElement
   }
 
   const getTheIndexOfTheSelectedElement = () => {
@@ -15,7 +24,9 @@ export const useNavigation = (origin, containerRef, axis, elementsSelector = '[d
     return element ? parseInt(element.getAttribute('nav-index')) : 0
   }
 
-  const setNavigation = index => selectElement(getAllElements()[index] || document.body)
+  const setNavigation = index => {
+    selectElement(getAllElements()[index] || document.body)
+  }
 
   const navigatePrevious = () => {
     const allElements = getAllElements()

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -1,22 +1,12 @@
 import { useState, useEffect } from 'preact/hooks'
 import { useSoftkey } from 'hooks'
 
-export const useNavigation = (origin, containerRef, axis, elementsSelector = '[data-selectable]') => {
+export const useNavigation = (origin, containerRef, listRef, axis, elementsSelector = '[data-selectable]') => {
   const [current, setCurrent] = useState({ type: null, index: 0, key: null })
 
-  const getAllElements = () => {
-    if (containerRef.current === undefined) {
-      return document.querySelectorAll(elementsSelector)
-    }
+  const getAllElements = () => containerRef.current.querySelectorAll(elementsSelector)
 
-    const grandparentContainer = containerRef.current.parentNode.parentNode
-    return grandparentContainer.querySelectorAll(elementsSelector)
-  }
-
-  const getSelectedElement = () => {
-    const grandparentContainer = containerRef.current.parentNode.parentNode
-    return grandparentContainer.querySelector('[nav-selected=true]')
-  }
+  const getSelectedElement = () => containerRef.current.querySelector('[nav-selected=true]')
 
   const getTheIndexOfTheSelectedElement = () => {
     const element = getSelectedElement()
@@ -79,21 +69,21 @@ export const useNavigation = (origin, containerRef, axis, elementsSelector = '[d
   })
 
   useEffect(() => {
-    if (!containerRef.current) return
+    if (!listRef.current) return
     const element = getSelectedElement()
     if (!element) return
     if (element.tagName === 'INPUT') return
 
     // todo: cache the next line since it doesn't change
-    const containerRect = containerRef.current.getBoundingClientRect()
+    const containerRect = listRef.current.getBoundingClientRect()
     const rect = element.getBoundingClientRect()
     if (rect.bottom > containerRect.bottom) {
       // scroll down
-      containerRef.current.scrollTop += (rect.bottom - containerRect.bottom)
+      listRef.current.scrollTop += (rect.bottom - containerRect.bottom)
     }
     if (rect.top < containerRect.top) {
       // scroll up
-      containerRef.current.scrollTop -= (containerRect.top - rect.top)
+      listRef.current.scrollTop -= (containerRect.top - rect.top)
     }
   })
 

--- a/src/hooks/useNavigation.js
+++ b/src/hooks/useNavigation.js
@@ -23,9 +23,7 @@ export const useNavigation = (origin, containerRef, axis, elementsSelector = '[d
     return element ? parseInt(element.getAttribute('nav-index')) : 0
   }
 
-  const setNavigation = index => {
-    selectElement(getAllElements()[index] || document.body)
-  }
+  const setNavigation = index => selectElement(getAllElements()[index] || document.body)
 
   const navigatePrevious = () => {
     const allElements = getAllElements()


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T250253

### Problem Statement

When we changed the article menu so that popups stack, in order to get the desired back key behavior when working on [backspace key feature](https://github.com/wikimedia/wikipedia-kaios/pull/197/files), a bug was introduced because `useNavigation` hook was not prepared to handle a specific case such as `ArticleLanguage` stacked on top of `ArticleMenu`. What was happening is that on every `getAllElements()` call, it was actually getting all elements from both the first and second popup. This was messing up navigation altogether. 

### Solution

At first I was trying to let it grab all elements from both popups and then slicing the array to handle the corresponding elements, but this approach wasn't really working correctly (branch `T250253-article-menu-language-first-approach-idea` for the curious). I opted instead for taking advantage of the `elementsSelector` argument to have the hook grab all the correct elements when `ArticleLanguage` is the `origin`. This required an update to `getSelectedElement()` so that it selects the correct element from the 'active' (latest) popup.

### Note

Still a mystery to me why the first piece of code below works but the second one doesn't

```
allNavSelectedTrue.forEach(element => {
    console.log(‘element.attributes...', element.attributes)
    if (element.getAttribute(currentSelector)) {
       selectedElement = element
    }
})

const selectedElement = Array.from(allNavSelectedTrue).find(element => {
    return element.getAttribute(currentSelector) === true // returns null
})

```
