### PR TITLE
Add Intl.PluralRules polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6998,6 +6998,12 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
+    "intl-pluralrules": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/intl-pluralrules/-/intl-pluralrules-1.2.0.tgz",
+      "integrity": "sha512-7v29fFKsaPquXezxttUNFdE6LQUD41I8JX76royEWBPuYIEruvfvprU3d8CsiNVIieVg/VeV2ee5WI0w0Vs2Sg==",
+      "dev": true
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "grunt-banana-checker": "^0.8.1",
     "http-server": "^0.11.1",
+    "intl-pluralrules": "^1.2.0",
     "less": "^3.11.1",
     "less-loader": "^5.0.0",
     "style-loader": "^1.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import 'preact/debug'
 import { h, render } from 'preact'
+import 'intl-pluralrules'
 import Banana from 'banana-i18n'
 import {
   setAppLanguage, getAppLanguage, setDeviceLanguage, getDeviceLanguage,


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T251255

### Problem Statement

You don't get this error on a modern browser, in the lower version of firefox < 58, and in KaiOS devices, the application throws error when calling Intl.PluralRules

### Solution

Polyfill solution for Intl.PluralRules

### Note
