### PR TITLE
Map kok-IN to gom (Goan Konkani Wikipedia)

### DIFF
--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1453,7 +1453,7 @@ const languages = [
   },
   {
     canonical_name: 'Goan Konkani (Devanagari script)',
-    code: 'gom-deva',
+    code: 'gom',
     name: '\u0917\u094B\u0935\u093E \u0915\u094B\u0902\u0915\u0923\u0940'
   }
 ]
@@ -1548,8 +1548,17 @@ export const checkHasDeviceLanguageChanged = () => {
   return getCurrentDeviceLanguage() !== localStorage.getItem('language-device')
 }
 
+const getAlias = lang => {
+  // Jio uses `kok-IN` for Konkani but Wikipedia uses `gom`
+  const aliases = {
+    'kok-IN': 'gom'
+  }
+
+  return aliases[lang] || lang
+}
+
 const getCurrentDeviceLanguage = () => {
-  const navigatorLang = navigator.language
+  const navigatorLang = getAlias(navigator.language)
   return navigatorLang.includes('-')
     ? navigatorLang.substr(0, navigatorLang.indexOf('-'))
     : navigatorLang


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T251791

### Problem Statement

For the Goan Konkani language, Jio uses the kok-IN code but Wikipedia uses the gom code.

### Solution

Map kok-IN to gom internally.

### Note
