### PR TITLE
guard reference before showing the popup

### DIFF
--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -55,7 +55,9 @@ const ArticleSection = ({
       }
     },
     reference: ({ referenceId }) => {
-      showReferencePreview({ reference: references[referenceId], lang })
+      if (references[referenceId]) {
+        showReferencePreview({ reference: references[referenceId], lang })
+      }
     },
     section: ({ text, anchor }) => {
       // @todo styling to be confirmed with design

--- a/src/components/QuickFacts.js
+++ b/src/components/QuickFacts.js
@@ -24,10 +24,12 @@ export const QuickFacts = ({ article, goToArticleSubpage, close, closeAll }) => 
 
   const linkHandlers = {
     reference: ({ referenceId }) => {
-      showReferencePreview({
-        reference: article.references[referenceId],
-        lang: article.contentLang
-      })
+      if (article.references[referenceId]) {
+        showReferencePreview({
+          reference: article.references[referenceId],
+          lang: article.contentLang
+        })
+      }
     },
     section: ({ text, anchor }) => {
       // @todo styling to be confirmed with design


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T252387

### Problem Statement

In some articles, contain reference markup but missing the reference object

### Solution

do not open the reference preview popup when there isn't ref object found in the code

### Note
