### PR TITLE
Apply image style to figure-inline

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "selector-attribute-quotes": null,
     "no-descending-specificity": null,
-    "declaration-no-important": null
+    "declaration-no-important": null,
+    "selector-type-no-unknown": null
   }
 }

--- a/style/article.less
+++ b/style/article.less
@@ -149,7 +149,8 @@
 					}
 				}
 
-				figure {
+				figure,
+				figure-inline {
 					position: relative;
 					width: 135px;
 					left: calc( 100vw - 50% - 97.5px );


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T249105

### Problem Statement

Some images didn't get the proper image treatment since it was applied only to figure.

### Solution

Apply the image treatment to figure-inline as well.

