### PR TITLE
Fix image gallery rendering

### DIFF
--- a/cypress/integration/special-cases.js
+++ b/cypress/integration/special-cases.js
@@ -32,8 +32,8 @@ describe('special cases tests', () => {
     })
     cy.rightArrow()
     cy.enter()
-    cy.get('.gallery.hasHeader>.header').should('be.visible')
-    cy.get('.gallery.hasHeader>.img>img').should('be.visible').should('have.attr', 'src', 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Tupolev_Tu-154B%2C_Tarom_AN0679876.jpg/640px-Tupolev_Tu-154B%2C_Tarom_AN0679876.jpg')
+    cy.get('.gallery-view.hasHeader>.header').should('be.visible')
+    cy.get('.gallery-view.hasHeader>.img>img').should('be.visible').should('have.attr', 'src', 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Tupolev_Tu-154B%2C_Tarom_AN0679876.jpg/640px-Tupolev_Tu-154B%2C_Tarom_AN0679876.jpg')
   })
 
   it('check goto quickfacts holly', () => {

--- a/cypress/page-objects/article-page.js
+++ b/cypress/page-objects/article-page.js
@@ -27,7 +27,7 @@ export class ArticlePage {
   }
 
   galleryImage () {
-    return cy.get('div.gallery > div.img > img')
+    return cy.get('div.gallery-view > div.img > img')
   }
 
   galleryPopupHeader () {

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -95,7 +95,7 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
   }, [currentIndex])
 
   return (
-    <div class={`gallery ${items[currentIndex].caption ? 'hasHeader' : ''}`}>
+    <div class={`gallery-view ${items[currentIndex].caption ? 'hasHeader' : ''}`}>
       {
         items[currentIndex].caption && (
           <div class='header'>

--- a/style/article.less
+++ b/style/article.less
@@ -153,8 +153,8 @@
 				figure-inline {
 					position: relative;
 					width: 135px;
-					left: calc( 100vw - 50% - 97.5px );
-					margin: 0;
+					margin-left: auto;
+					margin-right: auto;
 					text-align: center;
 					box-shadow: 0 1px 3px 0 rgba( 0, 0, 0, 0.15 );
 					border: solid 0.5px #c8ccd1;
@@ -207,7 +207,7 @@
 							width: 100% !important;
 							text-align: center;
 
-							div {
+							div.thumb {
 								width: 100% !important;
 							}
 						}

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -1,4 +1,4 @@
-.gallery {
+.gallery-view {
 	width: 100%;
 	height: calc( 100vh - @softkeysHeight );
 


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T247260

### Problem Statement

Some images render on top of each other or on top of article text.

### Solution

Rename `.gallery` to `.gallery-view` so it doesn't conflict with the `.gallery` class used in articles. Also adjust margin and position.

