### PR TITLE
Apply language blacklist even if the phone is set to use it

### DIFF
--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1559,7 +1559,8 @@ const getAlias = lang => {
 
 const getCurrentDeviceLanguage = () => {
   const navigatorLang = getAlias(navigator.language)
-  return navigatorLang.includes('-')
+  const code = navigatorLang.includes('-')
     ? navigatorLang.substr(0, navigatorLang.indexOf('-'))
     : navigatorLang
+  return isSupportedForReading(code) ? code : 'en'
 }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T253158

### Problem Statement

Blacklisted language can be used when the phone is set to it but it breaks the application.

### Solution

When the device is using a blacklisted language, fallback to english.

### Note
