### PR TITLE
Let components abort pending requests

### DIFF
--- a/src/api/getRandomArticleTitle.js
+++ b/src/api/getRandomArticleTitle.js
@@ -3,5 +3,5 @@ import { buildPcsUrl, cachedFetch } from 'utils'
 export const getRandomArticleTitle = lang => {
   const url = buildPcsUrl(lang, 'title', 'random')
 
-  return cachedFetch(url, data => data.items[0].title, true, false)
+  return cachedFetch(url, data => data.items[0].title, false)
 }

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -28,5 +28,5 @@ export const search = (lang, term) => {
         imageUrl: p.thumbnail && p.thumbnail.source
       }
     })
-  }, true)
+  })
 }

--- a/src/hooks/useArticleMediaInfo.js
+++ b/src/hooks/useArticleMediaInfo.js
@@ -5,8 +5,9 @@ export const useArticleMediaInfo = (lang, title, fromCommon) => {
   const [media, setMedia] = useState()
 
   useEffect(() => {
-    getArticleMediaInfo(lang, title, fromCommon)
-      .then(media => setMedia(media))
+    const [promise, abort] = getArticleMediaInfo(lang, title, fromCommon)
+    promise.then(setMedia)
+    return abort
   }, [])
 
   return media

--- a/src/hooks/useArticleSummary.js
+++ b/src/hooks/useArticleSummary.js
@@ -5,8 +5,9 @@ export const useArticleSummary = (lang, title) => {
   const [summary, setSummary] = useState()
 
   useEffect(() => {
-    getArticleSummary(lang, title)
-      .then(summary => setSummary(summary))
+    const [promise, abort] = getArticleSummary(lang, title)
+    promise.then(setSummary)
+    return abort
   }, [lang, title])
 
   return summary

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -9,10 +9,9 @@ export const useSearch = (lang) => {
 
   useEffect(() => {
     if (query) {
-      search(lang, query)
-        .then(results => {
-          setSearchResults(results)
-        })
+      const [request, abort] = search(lang, query)
+      request.then(setSearchResults)
+      return abort
     } else {
       setSearchResults(null)
     }

--- a/src/hooks/useSearchArticleLanguage.js
+++ b/src/hooks/useSearchArticleLanguage.js
@@ -7,11 +7,12 @@ export const useSearchArticleLanguage = (lang, title) => {
   const [allLanguages, setAllLanguages] = useState([])
 
   useEffect(() => {
-    getLanglinks(lang, title)
-      .then(languages => {
-        setAllLanguages(languages)
-        setItems(getInitialLangList(languages))
-      })
+    const [promise, abort] = getLanglinks(lang, title)
+    promise.then(languages => {
+      setAllLanguages(languages)
+      setItems(getInitialLangList(languages))
+    })
+    return abort
   }, [])
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Phabricator https://phabricator.wikimedia.org/T244021

### Problem Statement

Components issue network requests. It is possible for those to resolve after the component has been unmounted. In this case, calling setState generates a runtime error and potentially a memory leak.

### Solution

Make `cachedFetch` return a promise and an abort function for components to return in their `useEffect`.

### Note
