### PR TITLE
T250642: bring back the gallery black background

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -93,8 +93,12 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
       galleryNode.classList.remove(galleryClass)
     })
 
-    img.height >= img.width ? galleryNode.classList.add('portrait') : galleryNode.classList.add('landscape')
-    if (items[currentIndex].caption) galleryNode.classList.add('hasHeader')
+    const orientationClass = img.height >= img.width ? 'portrait' : 'landscape'
+    galleryNode.classList.add(orientationClass)
+
+    if (items[currentIndex].caption) {
+      galleryNode.classList.add('hasHeader')
+    }
   }
 
   useSoftkey('Gallery', {
@@ -117,7 +121,7 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
         )
       }
       <div class='img'>
-        <img onLoad={e => onImageLoad(e)} src={items[currentIndex].thumbnail} />
+        <img onLoad={onImageLoad} src={items[currentIndex].thumbnail} />
       </div>
     </div>
   )

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import { useRef, useLayoutEffect } from 'preact/hooks'
+import { useRef, useLayoutEffect, useState } from 'preact/hooks'
 import { useI18n, useSoftkey, usePopup, useRange, useArticleMediaInfo } from 'hooks'
 
 const MAX_DESCRIPTION_HEIGHT = 45
@@ -83,6 +83,12 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
     currentIndex, onPrevImage, onNextImage
   ] = useRange(getInitialIndex(items, startFileName), items.length - 1)
   const [showAboutPopup] = usePopup(AboutContainer, { stack: true })
+  const [isPortrait, setIsPortrait] = useState()
+
+  const onImageLoad = ({ target: img }) => {
+    console.log('onImageLoad - img...', img)
+    img.height >= img.width ? setIsPortrait(true) : setIsPortrait(false) // TODO: if they are equal?
+  }
 
   useSoftkey('Gallery', {
     left: i18n('softkey-close'),
@@ -95,7 +101,7 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
   }, [currentIndex])
 
   return (
-    <div class={`gallery-view ${items[currentIndex].caption ? 'hasHeader' : ''}`}>
+    <div class={`gallery-view ${items[currentIndex].caption ? 'hasHeader' : ''} ${isPortrait ? 'portrait' : 'landscape'}`}>
       {
         items[currentIndex].caption && (
           <div class='header'>
@@ -104,7 +110,7 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
         )
       }
       <div class='img'>
-        <img src={items[currentIndex].thumbnail} />
+        <img onLoad={e => onImageLoad(e)} src={items[currentIndex].thumbnail} />
       </div>
     </div>
   )

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import { useRef, useLayoutEffect, useState } from 'preact/hooks'
+import { useRef, useLayoutEffect } from 'preact/hooks'
 import { useI18n, useSoftkey, usePopup, useRange, useArticleMediaInfo } from 'hooks'
 
 const MAX_DESCRIPTION_HEIGHT = 45
@@ -84,11 +84,17 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
     currentIndex, onPrevImage, onNextImage
   ] = useRange(getInitialIndex(items, startFileName), items.length - 1)
   const [showAboutPopup] = usePopup(AboutContainer, { stack: true })
-  const [isPortrait, setIsPortrait] = useState()
 
   const onImageLoad = ({ target: img }) => {
-    console.log('onImageLoad - img...', img)
-    img.height >= img.width ? setIsPortrait(true) : setIsPortrait(false) // TODO: if they are equal?
+    const galleryNode = containerRef.current
+    const galleryClasses = ['hasHeader', 'portrait', 'landscape']
+
+    galleryClasses.forEach(galleryClass => {
+      galleryNode.classList.remove(galleryClass)
+    })
+
+    img.height >= img.width ? galleryNode.classList.add('portrait') : galleryNode.classList.add('landscape')
+    if (items[currentIndex].caption) galleryNode.classList.add('hasHeader')
   }
 
   useSoftkey('Gallery', {
@@ -101,15 +107,8 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
     onKeyBackspace: close
   }, [currentIndex])
 
-  useLayoutEffect(() => {
-    if (!containerRef.current) return
-
-    const descriptionNode = containerRef.current
-    isPortrait ? descriptionNode.classList.add('portrait') : descriptionNode.classList.remove('portrait')
-  })
-
   return (
-    <div class={`gallery-view ${items[currentIndex].caption ? 'hasHeader' : ''}`} ref={containerRef}>
+    <div class='gallery-view' ref={containerRef}>
       {
         items[currentIndex].caption && (
           <div class='header'>

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -79,6 +79,7 @@ const LoadingAbout = () => {
 
 export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
   const i18n = useI18n()
+  const containerRef = useRef()
   const [
     currentIndex, onPrevImage, onNextImage
   ] = useRange(getInitialIndex(items, startFileName), items.length - 1)
@@ -100,8 +101,15 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang }) => {
     onKeyBackspace: close
   }, [currentIndex])
 
+  useLayoutEffect(() => {
+    if (!containerRef.current) return
+
+    const descriptionNode = containerRef.current
+    isPortrait ? descriptionNode.classList.add('portrait') : descriptionNode.classList.remove('portrait')
+  })
+
   return (
-    <div class={`gallery-view ${items[currentIndex].caption ? 'hasHeader' : ''} ${isPortrait ? 'portrait' : 'landscape'}`}>
+    <div class={`gallery-view ${items[currentIndex].caption ? 'hasHeader' : ''}`} ref={containerRef}>
       {
         items[currentIndex].caption && (
           <div class='header'>

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -36,13 +36,7 @@
 
 	&.portrait {
 		.img {
-			border: solid #2888; // Testing...
-		}
-	}
-
-	&.landscape {
-		.img {
-			border: solid #827;
+			border: solid #ffa500; // Testing...
 		}
 	}
 }

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -1,6 +1,6 @@
 .gallery-view {
 	width: 100%;
-	height: calc( 100vh - @softkeysHeight );
+	height: @availableHeight;
 	background-color: #000;
 
 	.header {
@@ -28,7 +28,7 @@
 
 	&.portrait {
 		.img {
-			height: calc( 100vh - @softkeysHeight );
+			height: @availableHeight; // Required under portrait for black background to work on device
 		}
 
 		img {
@@ -39,7 +39,7 @@
 
 	&.landscape {
 		.img {
-			height: calc( 100vh - @softkeysHeight );
+			height: @availableHeight; // Required under landscape for black background to work on device
 		}
 
 		img {

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -1,6 +1,7 @@
 .gallery-view {
 	width: 100%;
 	height: calc( 100vh - @softkeysHeight );
+	background-color: #000;
 
 	.header {
 		font-size: 17px;
@@ -30,6 +31,18 @@
 	&.hasHeader {
 		.img {
 			height: calc( 100vh - @softkeysHeight - 27px );
+		}
+	}
+
+	&.portrait {
+		.img {
+			border: solid #2888; // Testing...
+		}
+	}
+
+	&.landscape {
+		.img {
+			border: solid #827;
 		}
 	}
 }

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -19,24 +19,37 @@
 		align-items: center;
 		justify-content: center;
 		flex-direction: column;
-		height: calc( 100vh - @softkeysHeight );
+
+		img {
+			background-color: #fff;
+			object-fit: contain;
+		}
+	}
+
+	&.portrait {
+		.img {
+			height: calc( 100vh - @softkeysHeight );
+		}
+
+		img {
+			height: 100%;
+			width: auto;
+		}
+	}
+
+	&.landscape {
+		.img {
+			height: calc( 100vh - @softkeysHeight );
+		}
 
 		img {
 			max-width: 100%;
-			background-color: #fff;
-			object-fit: contain;
 		}
 	}
 
 	&.hasHeader {
 		.img {
 			height: calc( 100vh - @softkeysHeight - 27px );
-		}
-	}
-
-	&.portrait {
-		.img {
-			border: solid #ffa500; // Testing...
 		}
 	}
 }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T250642

### Problem Statement

We had decided to temporarily remove the black background in the gallery as a consequence of [another gallery-related task](https://phabricator.wikimedia.org/T248443). The goal here is to bring the black background back and have the gallery display it correctly for both landscape and portrait images on device.

### Solution

After many deploys trying out a number of ideas, I was finally able to get the device to render images properly with the use of `onImageLoad` only. The solution consists of looking at the dimensions of each new image in the gallery and deciding based on its width and height whether said image is a portrait or landscape. With this information, we can then set CSS appropriately for each case. Note that:

- You will notice there are three classes in `gallery.less` that pertain to the height/width of the images: `portrait`, `landscape` and `hasHeader`
- In order to obtain an accurate reading of the image's width/height, we have to first remove the classes that are related to that (`portrait`, `landscape` and `hasHeader`)
  - This was probably the hardest to actually realize after all the trial and errors. The behaviors that I see on device if you don't remove the classes first vary and are all ultimately wrong: landscape images off-centered, portrait images with a white background, etc. If we don't clean up the image first (by removing classes), the height/width readings are not accurate and thus the logic falls apart.
- You will see what seems to be a redundant and unnecessary line of code in `gallery.less`: the `height` being set in `.img`. We need it this way for this solution to work because when we remove the classes we must reset height for an accurate reading. 

I encourage you to test this on device and welcome ideas to make it simpler/better.

