### PR TITLE
T253018: only gallery images should be selectable

### DIFF
--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -39,7 +39,7 @@ const ArticleActions = ({ actions }) => {
 const ArticleSection = ({
   lang, imageUrl, anchor, title, description, actions, isFooter,
   content, page, goToSubpage, references,
-  articleTitle, suggestedArticles, showGallery
+  articleTitle, suggestedArticles, showGallery, galleryItems
 }) => {
   const contentRef = useRef()
   const i18n = useI18n()
@@ -71,7 +71,7 @@ const ArticleSection = ({
     }
   }
 
-  useArticleLinksNavigation('Article', lang, contentRef, linkHandlers, [page, textSize])
+  useArticleLinksNavigation('Article', lang, contentRef, linkHandlers, [page, textSize], galleryItems)
 
   useLayoutEffect(() => {
     if (!contentRef.current) {
@@ -236,6 +236,7 @@ const ArticleInner = ({ lang, articleTitle, initialAnchor }) => {
         suggestedArticles={article.suggestedArticles}
         goToSubpage={goToArticleSubpage}
         showGallery={showGallery}
+        galleryItems={article.media}
         page={currentPage}
       />
     </div>

--- a/src/components/QuickFacts.js
+++ b/src/components/QuickFacts.js
@@ -45,7 +45,8 @@ export const QuickFacts = ({ article, goToArticleSubpage, close, closeAll }) => 
     article.contentLang,
     containerRef,
     linkHandlers,
-    [scrollPosition, textSize]
+    [scrollPosition, textSize],
+    article.media
   )
 
   return (

--- a/src/hooks/useArticleLinksNavigation.js
+++ b/src/hooks/useArticleLinksNavigation.js
@@ -21,7 +21,8 @@ export const useArticleLinksNavigation = (
   lang,
   contentRef,
   linkHandlers = {},
-  dependencies = []
+  dependencies = [],
+  galleryItems = []
 ) => {
   const i18n = useI18n()
   const [links, setLinks] = useState([])
@@ -44,7 +45,7 @@ export const useArticleLinksNavigation = (
   const hasLinks = () => links && links.length
 
   useEffect(() => {
-    const visibleLinks = findVisibleLinks(contentRef.current)
+    const visibleLinks = findVisibleLinks(contentRef.current, galleryItems)
     setLinks(visibleLinks)
     if (visibleLinks.length) {
       if (visibleLinks.indexOf(currentLink) === -1) {
@@ -143,7 +144,7 @@ const makeLinkClickEvent = link => {
   }
 }
 
-const findVisibleLinks = container => {
+const findVisibleLinks = (container, galleryItems) => {
   const links = container.querySelectorAll(SUPPORTED_LINKS)
   const visibleLinks = []
   let rect
@@ -160,6 +161,9 @@ const findVisibleLinks = container => {
     if (rect.y < 0 && (rect.y + rect.height < 0)) {
       continue
     }
+    if ((link.tagName === 'FIGURE' || link.tagName === 'FIGURE-INLINE') && !isImageInGallery(galleryItems, link)) {
+      continue
+    }
     if (rect.x > viewport.width || rect.y > (viewport.height - 30)) {
       // After the current page
       break
@@ -167,4 +171,15 @@ const findVisibleLinks = container => {
     visibleLinks.push(link)
   }
   return visibleLinks
+}
+
+const isImageInGallery = (galleryItems, link) => {
+  const aElement = link.querySelector('a')
+  if (!aElement) {
+    return false
+  }
+
+  const href = aElement.getAttribute('href')
+  const fileName = href.split(':')[1]
+  return galleryItems.find(media => media.canonicalizedTitle === fileName)
 }

--- a/src/hooks/useArticleLinksNavigation.js
+++ b/src/hooks/useArticleLinksNavigation.js
@@ -132,10 +132,7 @@ const makeLinkClickEvent = link => {
 
   if (link.tagName === 'FIGURE' || link.tagName === 'FIGURE-INLINE') {
     const aElement = link.querySelector('a')
-    const href = aElement.getAttribute('href')
-    // file name example in href : /wiki/File:Holly_Christmas_card_from_NLI.jpg
-    // split to match the api file name
-    const fileName = href.split(':')[1]
+    const fileName = getFileNameFromAnchorElement(aElement)
     return { type: 'image', fileName }
   }
 
@@ -179,7 +176,13 @@ const isImageInGallery = (galleryItems, link) => {
     return false
   }
 
-  const href = aElement.getAttribute('href')
-  const fileName = href.split(':')[1]
+  const fileName = getFileNameFromAnchorElement(aElement)
   return galleryItems.find(media => media.canonicalizedTitle === fileName)
+}
+
+const getFileNameFromAnchorElement = (aElement) => {
+  // file name example in href : /wiki/File:Holly_Christmas_card_from_NLI.jpg
+  // split to match the api file name
+  const href = aElement.getAttribute('href')
+  return href.split(':')[1]
 }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T253018

### Problem Statement

If an image is not supposed to be shown in the gallery, it shouldn't be selectable. Otherwise it leads to a buggy behavior where a user can click on an image (from article) and then see a different image in the gallery view. 

### Solution

Check whether the image in the article section is part of the gallery images before adding it as a `visibleLink`. This includes images shown in `QuickFacts`

### Note
