### PR TITLE
Update cypress to run on firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Build and Test
           command: |
             npm install
-            node ./node_modules/cross-env/src/bin/cross-env.js DISABLE_REQUEST_HEADER=1 npm run build
+            npm run build:ci
             npm run banana
             npm run start &
             npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Build and Test
           command: |
             npm install
-            npm run build
+            node ./node_modules/cross-env/src/bin/cross-env.js DISABLE_REQUEST_HEADER=1 npm run build
             npm run banana
             npm run start &
             npm test

--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -177,9 +177,7 @@ describe('Article view', () => {
   it('check text size remains after changing on preview', () => {
     goToCatArticle()
     articlePage.getArticleText().should('have.attr', 'style', 'font-size: 16px;')
-    articlePage.selectOptionFromActionsMenu('sections')
-    articleMenuPage.selectOptionFromSections('Taxonomy')
-    cy.enter()
+    cy.downArrow().enter()
     articlePage.decreaseTextSize()
     articlePage.decreaseTextSize()
     popupPage.getText().should('have.attr', 'style', 'font-size: 14px;')

--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -177,7 +177,9 @@ describe('Article view', () => {
   it('check text size remains after changing on preview', () => {
     goToCatArticle()
     articlePage.getArticleText().should('have.attr', 'style', 'font-size: 16px;')
-    cy.downArrow().downArrow().downArrow().enter()
+    articlePage.selectOptionFromActionsMenu('sections')
+    articleMenuPage.selectOptionFromSections('Taxonomy')
+    cy.enter()
     articlePage.decreaseTextSize()
     articlePage.decreaseTextSize()
     popupPage.getText().should('have.attr', 'style', 'font-size: 14px;')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "deploy": "cross-env INSTRUMENTATION=1 RAND=1 npm run build && npm run adb:connect && ( npm run b2g:uninstall || echo ) && npm run b2g:install",
     "cypress:lint": "eslint cypress/",
     "cypress:fix-lint": "eslint cypress/ --fix",
-    "cypress:run": "cypress run",
+    "cypress:run": "cypress run --browser firefox",
     "cypress:open": "cypress open",
     "testlocal": "npm run cypress:fix-lint && npm run cypress:run"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "npm run cypress:lint && npm run cypress:run",
     "build": "webpack --mode production",
-    "dev": "cross-env INSTRUMENTATION=1 RAND=1 webpack-dev-server --mode development",
+    "build:ci": "cross-env DISABLE_REQUEST_HEADER=1 npm run build",
+    "dev": "cross-env DISABLE_REQUEST_HEADER=1 INSTRUMENTATION=1 RAND=1 webpack-dev-server --mode development",
     "start": "http-server -p 8080",
     "banana": "banana-checker i18n/",
     "adb:connect": "adb forward tcp:6000 localfilesystem:/data/local/debugger-socket",

--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -49,7 +49,7 @@ export const cachedFetch = (url, transformFn, cache = true) => {
 }
 
 const sendLogWhenError = ({ status, response }, url) => {
-  if (isProd()) {
+  if (!isProd()) {
     return
   }
 

--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -15,7 +15,7 @@ export const cachedFetch = (url, transformFn, cache = true) => {
   const promise = new Promise((resolve, reject) => {
     xhr.responseType = 'json'
     xhr.open('GET', url)
-    if (isProd() && !isRequestHeaderDisabled()) {
+    if (!isRequestHeaderDisabled()) {
       xhr.setRequestHeader('User-Agent', `WikipediaApp/${appVersion()} ${navigator.userAgent}`)
       xhr.setRequestHeader('Referer', 'https://www.wikipedia.org')
     }

--- a/src/utils/cachedFetch.js
+++ b/src/utils/cachedFetch.js
@@ -1,4 +1,4 @@
-import { isProd, appVersion, sendErrorLog } from 'utils'
+import { isProd, appVersion, sendErrorLog, isRequestHeaderDisabled } from 'utils'
 
 // todo: Implement a real cache that keeps
 // the last N requests to keep memory usage
@@ -15,7 +15,7 @@ export const cachedFetch = (url, transformFn, cache = true) => {
   const promise = new Promise((resolve, reject) => {
     xhr.responseType = 'json'
     xhr.open('GET', url)
-    if (isProd()) {
+    if (isProd() && !isRequestHeaderDisabled()) {
       xhr.setRequestHeader('User-Agent', `WikipediaApp/${appVersion()} ${navigator.userAgent}`)
       xhr.setRequestHeader('Referer', 'https://www.wikipedia.org')
     }
@@ -49,7 +49,7 @@ export const cachedFetch = (url, transformFn, cache = true) => {
 }
 
 const sendLogWhenError = ({ status, response }, url) => {
-  if (!isProd()) {
+  if (isProd()) {
     return
   }
 

--- a/src/utils/featureFlags.js
+++ b/src/utils/featureFlags.js
@@ -6,3 +6,6 @@ export const isInstrumentationEnabled = () => INSTRUMENTATION
 
 /* eslint-disable-next-line no-undef */
 export const isRandomEnabled = () => RANDOM
+
+/* eslint-disable-next-line no-undef */
+export const isRequestHeaderDisabled = () => DISABLE_REQUEST_HEADER

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,8 @@ module.exports = {
       APP_VERSION: JSON.stringify(require('./package.json').version),
       INSTRUMENTATION: JSON.stringify(!!parseInt(process.env.INSTRUMENTATION)),
       // "RANDOM" is already used in the terminal, so using just "RAND"
-      RANDOM: JSON.stringify(!!parseInt(process.env.RAND))
+      RANDOM: JSON.stringify(!!parseInt(process.env.RAND)),
+      DISABLE_REQUEST_HEADER: JSON.stringify(!!parseInt(process.env.DISABLE_REQUEST_HEADER))
     }),
     new webpack.EnvironmentPlugin()
   ],


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

Our environment on the phone is firefox browser

### Solution

Update the cypress configuration and our app feature flag to be able to run on firefox

### Note

_I believe our app won't be able to work correctly when KaiOS updates the gecko engine to the latest, for example, if you run our app on chrome, the article page navigation doesn't work well due to the reason we are now developing it for the older firefox. The good thing is we may not need the `isProd` utils for setting request header._