### PR TITLE
T248171: add additional logic for device when checking links action

### DIFF
--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -177,7 +177,7 @@ describe('Article view', () => {
   it('check text size remains after changing on preview', () => {
     goToCatArticle()
     articlePage.getArticleText().should('have.attr', 'style', 'font-size: 16px;')
-    cy.downArrow().downArrow().downArrow().enter()
+    cy.downArrow().enter()
     articlePage.decreaseTextSize()
     articlePage.decreaseTextSize()
     popupPage.getText().should('have.attr', 'style', 'font-size: 14px;')

--- a/src/hooks/useArticleLinksNavigation.js
+++ b/src/hooks/useArticleLinksNavigation.js
@@ -103,7 +103,7 @@ export const useArticleLinksNavigation = (
 
 const makeLinkClickEvent = link => {
   const title = link.getAttribute('title')
-  if (title && link.pathname !== '/') {
+  if (title && !['/', '/index.html'].includes(link.pathname)) {
     if (title.includes(':') && INTERWIKI_KEYS.includes(title.split(':')[0])) {
       return { type: 'external', href: link.href }
     }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T248171

### Problem Statement

Device unable to have "goto" section feature

### Solution

due to the different pathname, add additional logic for device

### Note

browser works correctly now, but not device, therefore this change is for device