### PR TITLE
Add backspace key in confirm dialog component

### DIFF
--- a/src/components/ConfirmDialog.js
+++ b/src/components/ConfirmDialog.js
@@ -7,6 +7,7 @@ export const ConfirmDialog = ({ message, onSubmit, close, closeAll }) => {
   useSoftkey('ConfirmDialog', {
     left: i18n('softkey-close'),
     onKeyLeft: close,
+    onKeyBackspace: close,
     center: i18n('softkey-ok'),
     onKeyCenter: () => { onSubmit(); closeAll() }
   }, [])


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

missing backspace key in confirm dialog

### Solution

add it

### Note

this is the follow up fix for the https://github.com/wikimedia/wikipedia-kaios/pull/241