### PR TITLE
T254307: add onKeyBackspace handler to Search

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -31,6 +31,14 @@ export const Search = () => {
     }
   }
 
+  const onKeyBackspace = () => {
+    if (query && getCurrent().type === 'INPUT') {
+      setQuery(query.slice(0, -1))
+    } else {
+      window.close()
+    }
+  }
+
   const onInput = ({ target }) => {
     if (isOnline) {
       setQuery(target.value)
@@ -50,8 +58,9 @@ export const Search = () => {
     onKeyRight: () => { window.location.hash = '/settings' },
     center: current.type === 'DIV' ? i18n('centerkey-select') : '',
     onKeyCenter,
-    onKeyLeft: isRandomEnabled() ? goToRandomArticle : null
-  }, [current.type])
+    onKeyLeft: isRandomEnabled() ? goToRandomArticle : null,
+    onKeyBackspace
+  }, [current.type, query])
 
   useTracking('Search', lang)
 


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T254307

### Problem Statement

Using the backspace key on Search performs a soft/partial close (app stays running on the background) as opposed to a hard/full close (kills the app). With the app running on the background after a soft close, the app updates won't be picked up by device.

### Solution

According to the solution suggested in Phabricator as well as what I can find online [1], `window.close()` performs the hard close that we need to kill the app. Main question then is how we can actually test that to corroborate. 

The main evidence I was able to find to confirm the hard close is the behavior seen via the WebIDE, specifically the dev tools panel available with remote runtime:

* without `window.close` (so what's currently on `master`), pressing backspace closes the app but does not close the dev tools at all
  * data is not cleared from the WebIDE (network requests, `console.logs` for testing, etc)
  * you can reopen the app and continue interacting with the WebIDE
* with `window.close`, pressing backspace closes the app as well as all the WebIDE data
  * the dev tools disappear as if the connection with the app had been interrupted, suggesting the hard close

This is also visible if you deploy this branch and play with the backspace key when you are first presented with the onboarding screens:

* `Onboarding` does not currently have a `onKeyBackspace` handler
*  so if you press backspace on either the first, second or third screen, you should see a soft close
  * the app closes and when you open again, you should land in the same screen where you exited
* dev tools stay active
* if you advance on through the consent screen and make it to `Search`, then you will see the hard close behavior if you press backspace key
* note: as it stands right now, if you skip the onboarding it also gets marked as done. 
  * it's the same behavior as if you completed it hitting the 'get started' in the last screen
  * this is why you don't see the onboarding again after a hard close if you skip it or complete it

However I would still like to open the question to all of us: how else can we test this? Is there a way to test/replicate and actual app software update after a hard close?

CC @jpita 

---

[1]

https://github.com/kaiostech/sample-react/issues/13
https://stackoverflow.com/questions/60146146/dont-know-how-to-kill-app-process-in-kaios


