### PR TITLE
T255397 Offline status for consent page

### DIFF
--- a/src/components/Consent.js
+++ b/src/components/Consent.js
@@ -1,31 +1,40 @@
 import { h } from 'preact'
-import { useI18n, useSoftkey } from 'hooks'
+import { useI18n, useSoftkey, useOnlineStatus } from 'hooks'
 import { grantConsent, goto } from 'utils'
+import { OfflinePanel } from 'components'
 
 export const Consent = () => {
   const i18n = useI18n()
+  const isOnline = useOnlineStatus()
 
   const onAgree = () => {
-    grantConsent()
-    goto.search()
+    if (isOnline) {
+      grantConsent()
+      goto.search()
+    }
   }
 
   useSoftkey('ConsentMessage', {
-    center: i18n('softkey-consent-agree'),
+    center: isOnline ? i18n('softkey-consent-agree') : '',
     onKeyCenter: onAgree,
     left: i18n('softkey-consent-terms'),
     onKeyLeft: goto.termsOfUse,
     right: i18n('softkey-consent-policy'),
     onKeyRight: goto.privacyPolicy,
     backspace: () => { window.exit() }
-  }, [])
+  }, [isOnline])
 
   return (
     <div class='consent'>
       <div class='header'>{i18n('app-title')}</div>
       <div class='body'>
-        <div class='message'>{i18n('consent-policy-message')}</div>
-        <div class='message'>{i18n('consent-terms-message')}</div>
+        {
+          isOnline ? <div>
+            <div class='message'>{i18n('consent-policy-message')}</div>
+            <div class='message'>{i18n('consent-terms-message')}</div>
+          </div> : <OfflinePanel />
+        }
+
       </div>
     </div>
   )


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T255397

### Problem Statement

When we accept the terms (on first app boot after install) a call is sent to the logs. When offline, a user can still use some basic functionality on the app.

### Solution

Show the offline panel UI and hide the CSK button

### Note

_higher priority review task_