### PR TITLE
T236317: add specific arrow keys handlers

### DIFF
--- a/src/components/Feedback.js
+++ b/src/components/Feedback.js
@@ -89,11 +89,6 @@ export const Feedback = ({ close }) => {
     }
   }
 
-  const handleUpOrDownArrowKey = () => {
-    const { index } = getCurrent()
-    index === 0 ? setNavigation(1) : setNavigation(0)
-  }
-
   const getTextareaElement = () => containerRef.current.querySelector('textarea')
 
   const blurTextarea = () => {
@@ -109,9 +104,7 @@ export const Feedback = ({ close }) => {
     onKeyBackspace,
     onKeyCenter,
     onKeyArrowRight,
-    onKeyArrowLeft,
-    onKeyArrowDown: handleUpOrDownArrowKey,
-    onKeyArrowUp: handleUpOrDownArrowKey
+    onKeyArrowLeft
   }, [message, isOnline])
 
   useEffect(() => {

--- a/src/components/Feedback.js
+++ b/src/components/Feedback.js
@@ -10,7 +10,7 @@ export const Feedback = ({ close }) => {
   const [message, setMessage] = useState()
   const [showSuccessConfirmation] = usePopup(SuccessConfirmationPopup, { stack: true })
   const [showCancelConfirmation] = usePopup(CancelConfirmationPopup, { stack: true })
-  const [, setNavigation, getCurrent] = useNavigation('Feedback', containerRef, containerRef, 'y')
+  const [current, setNavigation, getCurrent] = useNavigation('Feedback', containerRef, containerRef, 'y')
   const isOnline = useOnlineStatus()
 
   const items = [
@@ -30,11 +30,9 @@ export const Feedback = ({ close }) => {
     }
   }
 
-  const onKeyBackspace = () => {
-    if (!isOnline && message) {
+  const onKeyBackspaceHandler = () => {
+    if (message) {
       showCancelConfirmation()
-    } else if (message && getCurrent().type === 'TEXTAREA') {
-      setMessage(message.slice(0, -1))
     } else {
       close()
     }
@@ -59,33 +57,21 @@ export const Feedback = ({ close }) => {
     }
   }
 
-  const onKeyArrowRight = () => {
+  const onKeyArrowRightHandler = () => {
     const { index } = getCurrent()
-    if (index > 0) {
-      if (items[index]) {
-        setNavigation(index + 1)
-      } else {
-        setNavigation(1)
-      }
+    if (items[index]) {
+      setNavigation(index + 1)
     } else {
-      const element = getTextareaElement()
-      const cursorPosition = element.selectionStart
-      element.setSelectionRange(cursorPosition + 1, cursorPosition + 1)
+      setNavigation(1)
     }
   }
 
-  const onKeyArrowLeft = () => {
+  const onKeyArrowLeftHandler = () => {
     const { index } = getCurrent()
-    if (index > 0) {
-      if (items[index - 2]) {
-        setNavigation(index - 1)
-      } else {
-        setNavigation(items.length)
-      }
+    if (items[index - 2]) {
+      setNavigation(index - 1)
     } else {
-      const element = getTextareaElement()
-      const cursorPosition = element.selectionStart
-      element.setSelectionRange(cursorPosition - 1, cursorPosition - 1)
+      setNavigation(items.length)
     }
   }
 
@@ -101,11 +87,11 @@ export const Feedback = ({ close }) => {
     onKeyRight,
     left: i18n('softkey-cancel'),
     onKeyLeft,
-    onKeyBackspace,
+    onKeyBackspace: !(message && current.type === 'TEXTAREA') && (() => onKeyBackspaceHandler()),
     onKeyCenter,
-    onKeyArrowRight,
-    onKeyArrowLeft
-  }, [message, isOnline])
+    onKeyArrowRight: !(current.type === 'TEXTAREA') && (() => onKeyArrowRightHandler()),
+    onKeyArrowLeft: !(current.type === 'TEXTAREA') && (() => onKeyArrowLeftHandler())
+  }, [message, isOnline, current])
 
   useEffect(() => {
     setNavigation(0)

--- a/src/components/Feedback.js
+++ b/src/components/Feedback.js
@@ -59,8 +59,45 @@ export const Feedback = ({ close }) => {
     }
   }
 
+  const onKeyArrowRight = () => {
+    const { index } = getCurrent()
+    if (index > 0) {
+      if (items[index]) {
+        setNavigation(index + 1)
+      } else {
+        setNavigation(1)
+      }
+    } else {
+      const element = getTextareaElement()
+      const cursorPosition = element.selectionStart
+      element.setSelectionRange(cursorPosition + 1, cursorPosition + 1)
+    }
+  }
+
+  const onKeyArrowLeft = () => {
+    const { index } = getCurrent()
+    if (index > 0) {
+      if (items[index - 2]) {
+        setNavigation(index - 1)
+      } else {
+        setNavigation(items.length)
+      }
+    } else {
+      const element = getTextareaElement()
+      const cursorPosition = element.selectionStart
+      element.setSelectionRange(cursorPosition - 1, cursorPosition - 1)
+    }
+  }
+
+  const handleUpOrDownArrowKey = () => {
+    const { index } = getCurrent()
+    index === 0 ? setNavigation(1) : setNavigation(0)
+  }
+
+  const getTextareaElement = () => containerRef.current.querySelector('textarea')
+
   const blurTextarea = () => {
-    const element = containerRef.current.querySelector('textarea')
+    const element = getTextareaElement()
     element.blur()
   }
 
@@ -70,7 +107,11 @@ export const Feedback = ({ close }) => {
     left: i18n('softkey-cancel'),
     onKeyLeft,
     onKeyBackspace,
-    onKeyCenter
+    onKeyCenter,
+    onKeyArrowRight,
+    onKeyArrowLeft,
+    onKeyArrowDown: handleUpOrDownArrowKey,
+    onKeyArrowUp: handleUpOrDownArrowKey
   }, [message, isOnline])
 
   useEffect(() => {


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T236317

### Problem Statement

This is a follow up to #216, it was requested to update `Feedback` navigation to:

> Use up/down keys on D-PAD to switch control between the text box and fine print and use left/right keys to switch between links

### Solution

I [shared my takeaways](https://phabricator.wikimedia.org/T236317#6230469) in the Phab ticket, it became evident to me that having both up/down and right/left arrow key handlers for a _single_ screen is basically not common/present anywhere else in the app, and therefore slightly against overall app consistency. If we want to go through with it though, to achieve the requested behavior then I'm proposing a `onKeyArrow*` for each of the four options and using `setNavigation` to select. Feels like some of the logic could be abstracted out to simplify the code but that may be part of a bigger refactor. 

Note that deleting characters of `message` is slightly buggy on the browser (if you try to delete a character that's not the last character), but I've tested and confirmed it works as expected on device (banana phone)
