### PR TITLE
Language lists use buttons

### DIFF
--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -25,7 +25,6 @@ describe('Article view', () => {
     cy.get('input').type('português')
     cy.get('.description').should('have.text', 'Gato')
     cy.downArrow().enter()
-    cy.clickDoneButton()
     articlePage.title().should('have.text', 'Gato')
   })
 
@@ -47,7 +46,6 @@ describe('Article view', () => {
     cy.get('input').type('português')
     cy.get('.description').should('have.text', 'Gato')
     cy.downArrow().enter()
-    cy.clickDoneButton()
     articlePage.title().should('have.text', 'Gato')
     articlePage.selectOptionFromActionsMenu('sections')
     articleMenuPage.selectOptionFromSections('Artigos_sugeridos')

--- a/cypress/integration/settings-spec.js
+++ b/cypress/integration/settings-spec.js
@@ -2,7 +2,6 @@
 
 import * as enJson from '../../i18n/en.json'
 import * as nlJson from '../../i18n/nl.json'
-import * as ptJson from '../../i18n/pt.json'
 import { SettingsPage } from '../page-objects/settings-page'
 import { SearchPage } from '../page-objects/search-page'
 import { LanguageSettingsPage } from '../page-objects/language-settings-page'
@@ -23,7 +22,6 @@ const settingsMenuListEnglishText = [enJson['settings-language'],
   enJson['settings-about-app'],
   enJson['settings-privacy-terms']]
 const languageSettingsPopupEnglishText = enJson['language-setting-message']
-const languageChangeDutchText = nlJson['language-change']
 const settingsMenuListDutchText = [nlJson['settings-language'],
   nlJson['settings-textsize'],
   nlJson['settings-about-wikipedia'],
@@ -63,8 +61,6 @@ describe('settings page', () => {
     cy.enter()
     cy.getRightSoftkeyButton().should('have.text', enJson['softkey-search'])
     cy.downArrow().enter()
-    languageSettingsPage.headerElement().should('have.text', languageChangeDutchText)
-    cy.getLeftSoftkeyButton().click()
     settingsPage.settingsList().should('have.text', settingsMenuListDutchText.join(''))
   })
 
@@ -75,8 +71,6 @@ describe('settings page', () => {
     cy.get('div.list').should('not.contain.text', 'Português')
     cy.get('input').type('port')
     cy.get('div.list').should('contain.text', 'Português')
-    cy.downArrow().enter()
-    languageSettingsPage.headerElement().should('have.text', ptJson['language-change'])
   })
 
   it('check text size popup', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -40,10 +40,6 @@ Cypress.Commands.add('clickMenuButton', () => {
   cy.getRightSoftkeyButton().contains(enJson['softkey-menu']).click()
 })
 
-Cypress.Commands.add('clickDoneButton', () => {
-  cy.getLeftSoftkeyButton().contains(enJson['softkey-done']).click()
-})
-
 Cypress.Commands.add('navigateToHomePage', () => {
   cy.setLocalStorage('has-onboard-before', true)
   cy.setLocalStorage('usage-data-consent', '{}') // Don't display consent screen

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Wikipedia KaiOS app",
   "private": true,
   "scripts": {
-    "test": "npm run cypress:lint && npm run cypress:run",
+    "test": "npm run cypress:lint && npm run cypress:run:firefox",
     "build": "webpack --mode production",
     "build:ci": "cross-env DISABLE_REQUEST_HEADER=1 npm run build",
     "dev": "cross-env DISABLE_REQUEST_HEADER=1 INSTRUMENTATION=1 RAND=1 webpack-dev-server --mode development",
@@ -16,7 +16,8 @@
     "deploy": "cross-env INSTRUMENTATION=1 RAND=1 npm run build && npm run adb:connect && ( npm run b2g:uninstall || echo ) && npm run b2g:install",
     "cypress:lint": "eslint cypress/",
     "cypress:fix-lint": "eslint cypress/ --fix",
-    "cypress:run": "cypress run --browser firefox",
+    "cypress:run": "cypress run",
+    "cypress:run:firefox": "cypress run --browser firefox",
     "cypress:open": "cypress open"
   },
   "repository": {

--- a/src/components/ArticleLanguage.js
+++ b/src/components/ArticleLanguage.js
@@ -1,7 +1,7 @@
 import { h } from 'preact'
 import { useRef, useEffect, useState } from 'preact/hooks'
 import { useNavigation, useI18n, useSoftkey, useSearchArticleLanguage } from 'hooks'
-import { RadioListView, Loading } from 'components'
+import { ListView, Loading } from 'components'
 import { goto } from 'utils'
 
 export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
@@ -51,6 +51,6 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
 
   return <div class='articlelanguage' ref={containerRef}>
     <input type='text' placeholder={i18n('search-language-placeholder')} value={query} onInput={e => setQuery(e.target.value)} data-selectable />
-    <RadioListView header={i18n('article-language-available', numOfLanglink)} items={items} containerRef={listRef} empty={i18n('no-result-found')} />
+    <ListView header={i18n('article-language-available', numOfLanglink)} items={items} containerRef={listRef} empty={i18n('no-result-found')} />
   </div>
 }

--- a/src/components/ArticleLanguage.js
+++ b/src/components/ArticleLanguage.js
@@ -20,18 +20,11 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
     const { index } = getCurrent()
     if (index > 0) {
       const itemIndex = index - 1
-      const item = items[itemIndex]
-      setArticleLang(item.lang)
-    }
-  }
-
-  const onKeyLeft = () => {
-    const item = items.find(item => item.isSelected)
-    if (item) {
-      const { lang, description } = item
+      const { lang, description } = items[itemIndex]
+      setArticleLang(lang)
       goto.article(lang, description, true)
+      closeAll()
     }
-    closeAll()
   }
 
   const onKeyBackspace = () => {
@@ -43,8 +36,8 @@ export const ArticleLanguage = ({ lang, title, close, closeAll }) => {
   }
 
   useSoftkey('ArticleLanguage', {
-    left: i18n('softkey-done'),
-    onKeyLeft,
+    left: i18n('softkey-cancel'),
+    onKeyLeft: () => closeAll(),
     right: i18n('softkey-search'),
     onKeyRight: () => setNavigation(0),
     center: i18n('centerkey-select'),

--- a/src/components/Language.js
+++ b/src/components/Language.js
@@ -23,6 +23,7 @@ export const Language = () => {
 
       setLang(item.lang)
       setAppLanguage(item.lang)
+      history.back()
     }
   }
 
@@ -31,7 +32,7 @@ export const Language = () => {
     onKeyRight: () => setNavigation(0),
     center: i18n('centerkey-select'),
     onKeyCenter,
-    left: i18n('softkey-done'),
+    left: i18n('softkey-cancel'),
     onKeyLeft: () => history.back(),
     onKeyBackspace: !(query && current.type === 'INPUT') && (() => history.back())
   }, [lang, items, current.type])


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T254311

### Problem Statement
Language lists use radio buttons. To select a language, the user has to select the radio button first and then click the left softkey to go back.

### Solution
Use buttons so that selecting a language applies it immediately. This is also how KaiOS does it.

### Note
Adding a npm task to run the browser tests with Chrome. Firefox doesn't work for me.