### PR TITLE
Quickfix for the RTL in Listview component

### DIFF
--- a/style/listview.less
+++ b/style/listview.less
@@ -24,6 +24,10 @@
 			display: flex;
 			justify-content: space-between;
 
+			&[ dir='rtl' ] {
+				text-align: right;
+			}
+
 			.info {
 				height: 100%;
 				overflow: hidden;


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

Recently, the search article language changes from RadioListView to ListView component, and the RTL Support for the component is missing in ListView

### Solution

Adding the rtl language styling for the ListView

### Note

UI language RTL support will visit this again, especially dealing with the image listview. But for now this is just for the normal listview.


![Screen Shot 2020-07-31 at 22 54 05](https://user-images.githubusercontent.com/2560096/89076842-534cb780-d381-11ea-80e0-89c712c4949b.png)
