### PR TITLE
ha language was incorrectly classified as RTL

### DIFF
--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1482,7 +1482,6 @@ const rtl = [
   'arz',
   'dv',
   'fa',
-  'ha',
   'he',
   'khw',
   'ks',


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

ha language was incorrectly classified as RTL

### Solution

Remove it from the RTL list.

### Note
