### PR TITLE
Localize article actions in content language

### DIFF
--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -22,14 +22,14 @@ const ArticleBody = memo(({ content }) => {
   )
 })
 
-const ArticleActions = ({ actions }) => {
-  const i18n = useI18n()
+const ArticleActions = ({ actions, lang }) => {
+  const contentI18n = useI18n(lang)
   return (
     <div class='article-actions'>
       { actions.filter(a => a.enabled).map(action => (
         <div class='article-actions-button' data-action={action.name} key={action.name}>
           <img src={`images/icon-${action.name}.svg`} />
-          <label>{i18n(`article-action-${action.name}`)}</label>
+          <label>{contentI18n(`article-action-${action.name}`)}</label>
         </div>
       )) }
     </div>
@@ -110,7 +110,7 @@ const ArticleSection = ({
               <div class='desc adjustable-font-size'>{description}</div>
             </Fragment>
           ) }
-          { actions && <ArticleActions actions={actions} /> }
+          { actions && <ArticleActions actions={actions} lang={lang} /> }
           { imageUrl && (
             <div class='indicator'>
               <img src='images/icon-down-arrow.svg' />


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T247443

### Problem Statement

Article actions are displayed as part of the article content, under the title on the first page. When the UI and content languages are different, this creates a surprising experience for the user. These actions are also available in the article menu, which remains in the UI language.

### Solution

Show the action labels in the article content language.

### Note
