### PR TITLE
Fix outline fragmentation by using border

### DIFF
--- a/style/article.less
+++ b/style/article.less
@@ -172,8 +172,7 @@
 
 					@{data-selected-selector} {
 						outline: solid 1px rgba( 51, 102, 204, 0.5 );
-						background-color: #ffeaf3;
-						display: inline-block;
+						background-color: #eaf3ff;
 					}
 				}
 

--- a/style/article.less
+++ b/style/article.less
@@ -172,17 +172,14 @@
 
 					@{data-selected-selector} {
 						outline: solid 1px rgba( 51, 102, 204, 0.5 );
-						background-color: #eaf3ff;
+						background-color: #ffeaf3;
+						display: inline-block;
 					}
 				}
 
 				span.mw-ref {
 					font-size: 50%;
 					vertical-align: super;
-
-					a {
-						unicode-bidi: bidi-override;
-					}
 				}
 
 				a {

--- a/style/article.less
+++ b/style/article.less
@@ -179,6 +179,10 @@
 				span.mw-ref {
 					font-size: 50%;
 					vertical-align: super;
+
+					a {
+						unicode-bidi: bidi-override;
+					}
 				}
 
 				a {

--- a/style/links.less
+++ b/style/links.less
@@ -4,9 +4,12 @@ span.mw-ref {
 	unicode-bidi: -webkit-isolate;
 	unicode-bidi: isolate;
 
+	// invisible border to reserve a pixel around the element
+	border: solid 1px rgba( 51, 102, 204, 0 );
+
 	&[ data-selected=true ] {
 		background-color: #eaf3ff;
-		outline: solid 1px rgba( 51, 102, 204, 0.48 );
-		-moz-outline-radius: 2px;
+		border: solid 1px rgba( 51, 102, 204, 0.48 );
+		border-radius: 2px;
 	}
 }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T260391

### Problem Statement

References have an outline around every single character. See task for screenshots.

### Solution

bidi-isolate the whole reference link so it doesn't switch direction and has a single outline.

### Note
