### PR TITLE
T262602 article history

### DIFF
--- a/src/utils/articleHistory.js
+++ b/src/utils/articleHistory.js
@@ -1,10 +1,14 @@
 import { normalizeTitle } from 'utils'
 
+const MAX = 100
 const list = []
 
 const add = (lang, title) => {
   const normalizedTitle = normalizeTitle(title)
   list.push({ lang, title: normalizedTitle })
+  if (list.length > MAX) {
+    list.shift()
+  }
 }
 
 const prev = () => {

--- a/src/utils/articleHistory.js
+++ b/src/utils/articleHistory.js
@@ -1,25 +1,14 @@
 import { normalizeTitle } from 'utils'
 
-const KEY = 'article-history'
-
-const get = () => {
-  return JSON.parse(localStorage.getItem(KEY))
-}
-
-const set = list => {
-  localStorage.setItem(KEY, JSON.stringify(list))
-}
+const list = []
 
 const add = (lang, title) => {
-  const list = JSON.parse(localStorage.getItem(KEY)) || []
   const normalizedTitle = normalizeTitle(title)
   list.push({ lang, title: normalizedTitle })
-  set(list)
 }
 
 const prev = () => {
-  const list = get()
-  if (!list.length) {
+  if (isEmpty()) {
     return false
   }
 
@@ -27,31 +16,25 @@ const prev = () => {
   list.pop()
 
   // return the previous article
-  const prevArticle = list.pop()
-
-  set(list)
-
-  return prevArticle
+  return list.pop()
 }
 
 const clear = () => {
-  localStorage.setItem(KEY, null)
+  list.length = 0
 }
 
 const isEmpty = () => {
-  return !(get() && get().length)
+  return list.length === 0
 }
 
 const hasPrev = () => {
-  const list = get()
-  return list && (list.length > 1)
+  return list.length > 1
 }
 
 const getPrev = () => {
-  const list = get()
   return list[list.length - 2]
 }
 
 export const articleHistory = {
-  get, set, add, prev, clear, isEmpty, hasPrev, getPrev
+  add, prev, clear, isEmpty, hasPrev, getPrev
 }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T262602

### Problem Statement

Article history can become large and fill up local storage.

### Solution

There's no reason to put it in local storage. Store in a regular variable and limit its size to 100.

### Note
