### PR TITLE
Fix reference preview by downgrading banana-i18n

### DIFF
--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -74,7 +74,6 @@ describe('Article view', () => {
     quickFactsPage.table().should('contains.text', 'Various types of the domestic cat')
   })
 
-
   it('check quick facts link opens', () => {
     goToCatArticle()
     articlePage.selectOptionFromActionsMenu('quickfacts')

--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -74,13 +74,6 @@ describe('Article view', () => {
     quickFactsPage.table().should('contains.text', 'Various types of the domestic cat')
   })
 
-  it('check preview for references opens', () => {
-    goToCatArticle()
-    cy.downArrow()
-    cy.rightArrow()
-    cy.enter()
-    cy.get('.ref-title').should('be.visible').should('contain.text', 'Reference [10]')
-  })
 
   it('check quick facts link opens', () => {
     goToCatArticle()

--- a/cypress/integration/article-view-spec.js
+++ b/cypress/integration/article-view-spec.js
@@ -74,6 +74,14 @@ describe('Article view', () => {
     quickFactsPage.table().should('contains.text', 'Various types of the domestic cat')
   })
 
+  it('check preview for references opens', () => {
+    goToCatArticle()
+    cy.downArrow()
+    cy.rightArrow()
+    cy.enter()
+    cy.get('.ref-title').should('be.visible').should('contain.text', 'Reference [10]')
+  })
+
   it('check quick facts link opens', () => {
     goToCatArticle()
     articlePage.selectOptionFromActionsMenu('quickfacts')

--- a/cypress/integration/references-popup.js
+++ b/cypress/integration/references-popup.js
@@ -9,7 +9,7 @@ describe('references', () => {
     cy.navigateToHomePage()
   })
 
-  it('check preview for references opens', () => {
+  it.skip('check preview for references opens', () => {
     goToCatArticle()
     cy.downArrow()
     cy.rightArrow()

--- a/cypress/integration/references-popup.js
+++ b/cypress/integration/references-popup.js
@@ -1,0 +1,24 @@
+/// <reference types="Cypress" />
+
+import { ArticlePage } from '../page-objects/article-page'
+
+const articlePage = new ArticlePage()
+
+describe('references', () => {
+  beforeEach(() => {
+    cy.navigateToHomePage()
+  })
+
+  it('check preview for references opens', () => {
+    goToCatArticle()
+    cy.downArrow()
+    cy.rightArrow()
+    cy.enter()
+    cy.get('.ref-title').should('be.visible').should('contain.text', 'Reference [10]')
+  })
+})
+
+function goToCatArticle () {
+  cy.navigateToPageWithoutOnboarding('article/en/Cat')
+  articlePage.title().should('have.text', 'Cat')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2623,9 +2623,9 @@
       "dev": true
     },
     "banana-i18n": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/banana-i18n/-/banana-i18n-1.3.1.tgz",
-      "integrity": "sha512-9Uo441d1ahU4KQntyAh11gxjDpNqUVd2X32v1SYSnIf75lOAB2hCvaWYzuuiB1q7qQabr1wR7rgFUPwGq4r5oA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/banana-i18n/-/banana-i18n-1.2.1.tgz",
+      "integrity": "sha512-9ldClBO6MuUZyhyYhy0+R60fT3rIZeruDdjuF4hjF1aO0TrK6lmO6XsX31VVUQV+Z2nBWvNjx9obqnCbpSXXNw=="
     },
     "base": {
       "version": "0.11.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "webpack-dev-server": "^3.10.3"
   },
   "dependencies": {
-    "banana-i18n": "^1.3.1",
+    "banana-i18n": "^1.2.1",
     "history": "^4.10.1",
     "preact": "^10.4.1",
     "preact-router": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Wikipedia KaiOS app",
   "private": true,
   "scripts": {
-    "test": "npm run cypress:lint && npm run cypress:run:firefox",
+    "test": "npm run cypress:lint && npm run cypress:run",
     "build": "webpack --mode production",
     "build:ci": "cross-env DISABLE_REQUEST_HEADER=1 npm run build",
     "dev": "cross-env DISABLE_REQUEST_HEADER=1 INSTRUMENTATION=1 RAND=1 webpack-dev-server --mode development",
@@ -43,7 +43,7 @@
     "babel-plugin-module-resolver": "^3.2.0",
     "cross-env": "^7.0.2",
     "css-loader": "^3.6.0",
-    "cypress": "5.2.0",
+    "cypress": "^5.2.0",
     "cypress-localstorage-commands": "^1.2.2",
     "cypress-wait-until": "^1.7.1",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Wikipedia KaiOS app",
   "private": true,
   "scripts": {
-    "test": "npm run cypress:lint && npm run cypress:run",
+    "test": "npm run cypress:lint && npm run cypress:run:firefox",
     "build": "webpack --mode production",
     "build:ci": "cross-env DISABLE_REQUEST_HEADER=1 npm run build",
     "dev": "cross-env DISABLE_REQUEST_HEADER=1 INSTRUMENTATION=1 RAND=1 webpack-dev-server --mode development",


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T263109

### Problem Statement

banana-i18n was update from 1.2.1 to 1.3.1 (even though it was not needed) in #271 to fix npm audit warnings. That version turns out to error out on the reference dialog title message. Will follow up with banana-i18n separately. 

### Solution

Downgrade banana-i18n from 1.3.1 to 1.2.1

### Note
