### PR TITLE
T260114 Configure input element mic icon

### DIFF
--- a/style/input.less
+++ b/style/input.less
@@ -1,0 +1,10 @@
+* {
+	[ dir='rtl' ] {
+		input {
+			&[ nav-selected='true' ] {
+				// mic icon position
+				background-position: left 6.8px center !important;
+			}
+		}
+	}
+}

--- a/style/input.less
+++ b/style/input.less
@@ -1,10 +1,6 @@
-* {
-	[ dir='rtl' ] {
-		input {
-			&[ nav-selected='true' ] {
-				// mic icon position
-				background-position: left 6.8px center !important;
-			}
-		}
+*[ dir='rtl' ] {
+	input[ nav-selected='true' ] {
+		// mic icon position
+		background-position: left 6.8px center !important;
 	}
 }

--- a/style/style.less
+++ b/style/style.less
@@ -2,6 +2,7 @@
 @import './variables';
 @import './layout';
 @import './mixin';
+@import './input';
 
 // component style
 @import './confirmdialog';


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T260114

### Problem Statement

input mic icon overlap with the placeholder in RTL language

### Solution

update the input css

### Note

**Tested on KaiOS NOKIA flip phone**; if you don't see any mic icon on your device, then this change doesn't affect it.

| LTR | RTL (1) | RTL (2) | RTL (3) |
| -- | -- | -- | -- |
| ![image](https://user-images.githubusercontent.com/2560096/93746762-f4bfef00-fbf5-11ea-88c3-486b3a2b7472.png) | ![image](https://user-images.githubusercontent.com/2560096/93746778-fb4e6680-fbf5-11ea-8412-25cdd4ffaaf8.png) | ![image](https://user-images.githubusercontent.com/2560096/93746799-01dcde00-fbf6-11ea-8a56-c9e039bbcef8.png) | ![image](https://user-images.githubusercontent.com/2560096/93746816-06a19200-fbf6-11ea-8346-17d8d5ff3595.png) |



 