### PR TITLE
remove unwanted package dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
     "intl-pluralrules": "^1.2.2",
     "less": "^3.12.2",
     "less-loader": "^5.0.0",
-    "lodash": "^4.17.20",
-    "minimatch": "^3.0.4",
     "style-loader": "^1.2.1",
     "stylelint": "^13.7.0",
     "stylelint-config-wikimedia": "^0.10.1",


### PR DESCRIPTION
I don't see a reason it stays in dev dependencies, that's the dependencies of the dev dependencies, and we don't use it in our source code.