### PR TITLE
T262592: fix production error ('v/h is undefined')

### DIFF
--- a/src/hooks/useSearchLanguage.js
+++ b/src/hooks/useSearchLanguage.js
@@ -42,7 +42,10 @@ const getInitialLangList = lang => {
   const list = prioritizedLanguages
 
   if (!list.find(language => language.lang === lang)) {
-    list.unshift(allLanguages.find(language => language.lang === lang))
+    const targetLanguage = allLanguages.find(language => language.lang === lang)
+    if (targetLanguage) {
+      list.unshift(targetLanguage)
+    }
   }
 
   return list

--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1509,6 +1509,9 @@ export const getDirection = langCode => {
 }
 
 export const isSupportedForReading = langCode => {
+  if (!languages.find(language => language.code === langCode)) {
+    return false
+  }
   return missingFont.indexOf(langCode) === -1
 }
 


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T262592

### Problem Statement

Our Kibana dashboard shows the following error info

```
message: v is undefined

---

stack trace:

getInitialLangList/<@app://kaios.wikipedia.org/dist/main.js:1:395829
getInitialLangList@app://kaios.wikipedia.org/dist/main.js:1:395809
useSearchLanguage/<@app://kaios.wikipedia.org/dist/main.js:1:395323
q@app://kaios.wikipedia.org/dist/main.js:1:283028
I.__c/</h.__h<@app://kaios.wikipedia.org/dist/main.js:1:285570
I.__c/<@app://kaios.wikipedia.org/dist/main.js:1:285531
I.__c@app://kaios.wikipedia.org/dist/main.js:1:285471
T@app://kaios.wikipedia.org/dist/main.js:1:267101
_/<@app://kaios.wikipedia.org/dist/main.js:1:262636
_@app://kaios.wikipedia.org/dist/main.js:1:262455

---

App version: 1.0.0.1231

```

### Solution

As part of the initial investigation, I noticed in the Kibana dashboard that for every `v is undefined` error there is a corresponding `h is undefined` error. They come in pairs. Each pair shares the `@timestamp` and `http.client_ip` address, so this led me to believe [T262594](https://phabricator.wikimedia.org/T262594) may be related to this [T262592](https://phabricator.wikimedia.org/T262592). One error points to the `RadioListView` component and the other to the `getInitialLangList` method, both used when changing app language (`getInitialLangList` sets the items used by the `RadioListView` when there's no query).

The above led us to following hypothesis: the `lang` variable passed to `getInitialLangList` (from `getAppLanguage`) may be a language that's not included in the long `languages` list in `utils/languages.js`. If `items` get 'unshifted' [1] with an undefined or some faulty value in `getInitialLangList`, that would likely cause issues in `RadioListView`. To test that hypothesis, I tried to:

> ...set your device to a language that doesn't exist in the app to check if it replicates some of those issues. One way to do that is to set the app language to `es`, then comment out `es` in the code and reload the app.

And as a result, saw the following issue appear which is consistent with what T262594 and T262592 hint at:

<img width="679" alt="image" src="https://user-images.githubusercontent.com/4752599/95488739-e7c82d00-0963-11eb-9194-d7e36c6daaf2.png">

As a solution I'm proposing to only unshift the list if the target language is found. 

Are there any more tests we can think of? 


---


### Note


[1]

```
Welcome to Node.js v13.8.0.
Type ".help" for more information.
>
> arr = [1, 2]
[ 1, 2 ]
>
> arr.unshift(0)
3
>
> arr
[ 0, 1, 2 ]
>
> arr.unshift(undefined)
4
>
> arr
[ undefined, 0, 1, 2 ]
>
> arr.unshift('undefined')
5
>
> arr
[ 'undefined', undefined, 0, 1, 2 ]
> undefined
undefined
```
