### PR TITLE
Specific data permission in the manifest

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -30,6 +30,8 @@
   "permissions": {
     "systemXHR": {
       "description": "Required to bypass CORS limitations."
-    }
+    },
+    "mobiledata": {},
+    "wifidata": {}
   }
 }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T267262

### Problem Statement

For some versions of KaiOS, access to the internet via mobile plan or wiki needs to be requested explicitly in the manifest.

### Solution

Specify `mobiledata` and `wifidata` permissions in the manifest.

### Note
