### PR TITLE
T267291 Add visual indicator to show more images inside gallery

### DIFF
--- a/images/arrow.svg
+++ b/images/arrow.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="28" height="28" viewBox="0 0 28 28">
+    <defs>
+        <filter id="u1p40heqwa" width="170%" height="170%" x="-35%" y="-25%" filterUnits="objectBoundingBox">
+            <feOffset dy="2" in="SourceAlpha" result="shadowOffsetOuter1"/>
+            <feGaussianBlur in="shadowOffsetOuter1" result="shadowBlurOuter1" stdDeviation="2"/>
+            <feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"/>
+            <feColorMatrix in="shadowBlurOuter1" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"/>
+        </filter>
+        <rect id="m34xv4vc1b" width="20" height="20" x="0" y="0" rx="10"/>
+        <path id="alofihj6bc" d="M4.55 0.7L3.5 1.75 8.749 7 3.5 12.25 4.55 13.3 10.85 7z"/>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <g>
+            <g>
+                <g transform="translate(-208 -160) translate(212 162)">
+                    <use fill="#000" filter="url(#u1p40heqwa)" xlink:href="#m34xv4vc1b"/>
+                    <use fill="#FFF" fill-opacity=".896" xlink:href="#m34xv4vc1b"/>
+                </g>
+                <g transform="translate(-208 -160) translate(212 162) translate(3 3)">
+                    <mask id="rrqs631p4d" fill="#fff">
+                        <use xlink:href="#alofihj6bc"/>
+                    </mask>
+                    <use fill="#000" xlink:href="#alofihj6bc"/>
+                    <g fill="#54595D" mask="url(#rrqs631p4d)">
+                        <path d="M0 0L14 0 14 14 0 14z"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -124,8 +124,16 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang, dir }) =>
           </div>
         )
       }
-      { currentIndex !== 0 && <div class='arrow left' /> }
-      { currentIndex < items.length - 1 && <div class='arrow right' /> }
+      {
+        currentIndex !== 0 && (
+          <div class={`arrow ${dir === 'rtl' ? 'right' : 'left'}`} />
+        )
+      }
+      {
+        currentIndex < items.length - 1 && (
+          <div class={`arrow ${dir === 'rtl' ? 'left' : 'right'}`} />
+        )
+      }
       <div class='img'>
         <img onLoad={onImageLoad} src={items[currentIndex].thumbnail} />
       </div>

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -124,8 +124,8 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang, dir }) =>
           </div>
         )
       }
-      { currentIndex !== 0 && <div class='arrow left'>{'<'}</div> }
-      { currentIndex < items.length - 1 && <div class='arrow right'>{'>'}</div> }
+      { currentIndex !== 0 && <div class='arrow left' /> }
+      { currentIndex < items.length - 1 && <div class='arrow right' /> }
       <div class='img'>
         <img onLoad={onImageLoad} src={items[currentIndex].thumbnail} />
       </div>

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -124,6 +124,8 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang, dir }) =>
           </div>
         )
       }
+      { currentIndex !== 0 && <div class='arrow left'>{'<'}</div> }
+      { currentIndex < items.length - 1 && <div class='arrow right'>{'>'}</div> }
       <div class='img'>
         <img onLoad={onImageLoad} src={items[currentIndex].thumbnail} />
       </div>

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -26,6 +26,25 @@
 		}
 	}
 
+	.arrow {
+		position: absolute;
+		top: calc( 50% - 10px );
+		width: 20px;
+		height: 20px;
+		padding: 1px 4.5px;
+		border-radius: 13px;
+		box-shadow: 0 2px 4px 0 rgba( 0, 0, 0, 0.5 );
+		background-color: rgba( 255, 255, 255, 0.9 );
+
+		&.left {
+			left: 8px;
+		}
+
+		&.right {
+			right: 8px;
+		}
+	}
+
 	&.portrait {
 		.img {
 			height: @availableHeight; // Required under portrait for black background to work on device
@@ -50,6 +69,10 @@
 	&.hasHeader {
 		.img {
 			height: calc( 100vh - @softkeysHeight - 27px );
+		}
+
+		.arrow {
+			top: calc( 50% - 10px + @softkeysHeight/2 );
 		}
 	}
 }

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -29,15 +29,13 @@
 	.arrow {
 		position: absolute;
 		top: calc( 50% - 10px );
-		width: 20px;
-		height: 20px;
-		padding: 1px 4.5px;
-		border-radius: 13px;
-		box-shadow: 0 2px 4px 0 rgba( 0, 0, 0, 0.5 );
-		background-color: rgba( 255, 255, 255, 0.9 );
+		width: 28px;
+		height: 28px;
+		background-image: url( /images/arrow.svg );
 
 		&.left {
 			left: 8px;
+			transform: scaleX( -1 );
 		}
 
 		&.right {


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T267291

### Problem Statement

In gallery view, no arrow indicator to show more images

### Solution

Add the arrow indicator svg within Gallery
 - [x] RTL support

### Note

| ![image](https://user-images.githubusercontent.com/2560096/100120840-b30f2700-2e78-11eb-9808-d5768303af80.png) | ![image](https://user-images.githubusercontent.com/2560096/100120863-ba363500-2e78-11eb-9402-a24bb2cf42b1.png) |
| --- | --- |
