### PR TITLE
T269158 Confirm dialog - Close event

### DIFF
--- a/cypress/integration/special-cases.js
+++ b/cypress/integration/special-cases.js
@@ -70,5 +70,6 @@ describe('special cases tests', () => {
     cy.get('.info').should('have.text', 'Go to Section "Related characters"')
     cy.backspace()
     cy.get('.info').should('not.be.visible')
+    cy.get('div.quickfacts table.infobox').should('be.visible')
   })
 })

--- a/src/components/ConfirmDialog.js
+++ b/src/components/ConfirmDialog.js
@@ -10,7 +10,7 @@ export const ConfirmDialog = ({
 
   const onDiscardFn = () => {
     onDiscard()
-    closeAll()
+    close()
   }
 
   useSoftkey('ConfirmDialog', {

--- a/src/components/Feedback.js
+++ b/src/components/Feedback.js
@@ -1,7 +1,7 @@
 import { h } from 'preact'
 import { useState, useRef, useEffect } from 'preact/hooks'
 import { useI18n, useSoftkey, useNavigation, usePopup, useOnlineStatus } from 'hooks'
-import { sendFeedback } from 'utils'
+import { sendFeedback, confirmDialog } from 'utils'
 import { OfflinePanel } from 'components'
 
 export const Feedback = ({ close }) => {
@@ -9,7 +9,6 @@ export const Feedback = ({ close }) => {
   const i18n = useI18n()
   const [message, setMessage] = useState()
   const [showSuccessConfirmation] = usePopup(SuccessConfirmationPopup, { stack: true })
-  const [showCancelConfirmation] = usePopup(CancelConfirmationPopup, { stack: true })
   const [current, setNavigation, getCurrent] = useNavigation('Feedback', containerRef, containerRef, 'y')
   const isOnline = useOnlineStatus()
 
@@ -28,6 +27,15 @@ export const Feedback = ({ close }) => {
       }
       showSuccessConfirmation()
     }
+  }
+
+  const showCancelConfirmation = () => {
+    confirmDialog({
+      title: i18n('feedback-cancel-header'),
+      message: i18n('feedback-cancel'),
+      onDiscardText: i18n('softkey-no'),
+      onSubmitText: i18n('softkey-yes')
+    })
   }
 
   const onKeyBackspaceHandler = () => {
@@ -134,25 +142,6 @@ const SuccessConfirmationPopup = ({ closeAll }) => {
     <div class='confirmation-popup'>
       <div class='header'>{i18n('feedback-success-header')}</div>
       <p class='preview-text'>{i18n('feedback-success')}</p>
-    </div>
-  )
-}
-
-const CancelConfirmationPopup = ({ close, closeAll }) => {
-  const i18n = useI18n()
-
-  useSoftkey('FeedbackCancelMessage', {
-    right: i18n('softkey-yes'),
-    onKeyRight: closeAll,
-    left: i18n('softkey-no'),
-    onKeyLeft: close,
-    onKeyBackspace: close
-  }, [])
-
-  return (
-    <div class='confirmation-popup'>
-      <div class='header'>{i18n('feedback-cancel-header')}</div>
-      <p class='preview-text'>{i18n('feedback-cancel')}</p>
     </div>
   )
 }

--- a/src/hooks/usePopup.js
+++ b/src/hooks/usePopup.js
@@ -19,6 +19,12 @@ export const usePopup = (component, options = {}) => {
   const show = props => {
     setPopupState(oldState => {
       let newState = [...oldState]
+
+      // prevent showing duplicate component
+      if (newState.find(state => state.id === component.name)) {
+        return newState
+      }
+
       const newPopup = {
         component,
         props: {
@@ -27,7 +33,7 @@ export const usePopup = (component, options = {}) => {
           closeAll
         },
         options,
-        id: Math.random()
+        id: component.name
       }
       if (options.stack) {
         newState.push(newPopup)

--- a/src/hooks/usePopup.js
+++ b/src/hooks/usePopup.js
@@ -19,12 +19,6 @@ export const usePopup = (component, options = {}) => {
   const show = props => {
     setPopupState(oldState => {
       let newState = [...oldState]
-
-      // prevent showing duplicate component
-      if (newState.find(state => state.id === component.name)) {
-        return newState
-      }
-
       const newPopup = {
         component,
         props: {
@@ -36,7 +30,10 @@ export const usePopup = (component, options = {}) => {
         id: component.name
       }
       if (options.stack) {
-        newState.push(newPopup)
+        // prevent showing duplicate component
+        if (!newState.find(state => state.id === newPopup.id)) {
+          newState.push(newPopup)
+        }
       } else {
         newState = [newPopup]
       }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T269158

### Problem Statement

The confirm dialog close event has `close` `closeAll` option, but it doesn't allow us to choose which one

### Solution

Make the confirm dialog utils/component more general
 - [x] 7a714c2 Reverse the previous changes of the key, now LSK `close()` and RSK `closeAll()` as the setting for confirm dialog utils
 - [x] 9a51818 306e564 prevent duplication of the stack id
 - [x] not allowing `close( <num_of_popup_closed> )`, << we don't have this cases yet, therefore ignore it.
 - [x] 5b4937369065bd61e78c3b8be8f428bfa8b7966b Update Feedback page to use `ConfirmDialog`
 - [x] dc8619d211477e3e9fa425e38a648bb89f46a06c Add test spec to prevent the test fail again in the future

### Note

touch to the confirm dialog and popup related code, including hook