### PR TITLE
Handle message parsing errors

### DIFF
--- a/src/hooks/useI18n.js
+++ b/src/hooks/useI18n.js
@@ -1,15 +1,35 @@
 import { useContext } from 'preact/hooks'
 import { I18nContext } from 'contexts'
-import { getAppLanguage } from 'utils'
+import { getAppLanguage, sendErrorLog } from 'utils'
 
 export const useI18n = (lang = getAppLanguage()) => {
   const banana = useContext(I18nContext)
 
-  return (key, ...args) => {
+  const i18n = (lang, key, ...args) => {
     if (lang !== banana.locale) {
       banana.setLocale(lang)
     }
 
     return banana.i18n(key, ...args)
+  }
+
+  return (key, ...args) => {
+    try {
+      // Try it in the requested language
+      return i18n(lang, key, ...args)
+    } catch (e) {
+      sendErrorLog(e)
+    }
+    try {
+      if (lang !== 'en') {
+        // If it failed and it was not English,
+        // Try it in English
+        return i18n('en', key, ...args)
+      }
+    } catch (e) {
+      sendErrorLog(e)
+    }
+    // Give up, return the key
+    return key
   }
 }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T269856

### Problem Statement

Some French messages have unsupported GENDER syntax. It breaks the app.

### Solution

The messages have been fixed in TWN but they should not have broken the app. This PR adds try/catch and a fallback chain to make sure it doesn't happen again.

### Note
