### PR TITLE
T268751 Use Fulltext search in Search screen

### DIFF
--- a/cypress/integration/search-spec.js
+++ b/cypress/integration/search-spec.js
@@ -14,7 +14,7 @@ describe('Article search', () => {
   it('search should show results', () => {
     searchPage.search('catt')
     searchPage.results().first()
-      .should('have.text', 'CattDisambiguation page providing links to topics that could be referred to by the same search term')
+      .should('have.text', 'CattCatt or CATT may refer to: Alfred Catt (1833–1919), Australian parliamentarian Anthony Catt (1933–2018), English cricketer Carrie Chapman Catt (1859–1947)')
   })
 
   it('results with image should show image', () => {
@@ -46,8 +46,8 @@ describe('Article search', () => {
       .children().first().next().should('have.class', 'img')
   })
 
-  it('should show empty result found when search for "adf23cv1"', () => {
-    searchPage.search('adf23cv1')
+  it('should show empty result found when search for "adf23cv111111"', () => {
+    searchPage.search('adf23cv111111')
     searchPage.getEmptyContent().should('have.text', enJson['no-result-found'])
   })
 

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -27,8 +27,9 @@ export const search = (lang, term) => {
       return []
     }
 
-    return Object.values(data.query.search).map(item => {
-      const page = data.query.pages.find(page => page.pageid === item.pageid)
+    const { search, pages } = data.query
+    return Object.values(search).map(item => {
+      const page = pages && pages.find(page => page.pageid === item.pageid)
       return {
         title: item.title,
         description: item.snippet,

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -22,10 +22,24 @@ export const search = (lang, term) => {
   // https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=no%20result%20page&format=json
   const params = {
     action: 'query',
+    prop: 'pageimages',
+    generator: 'search',
     srprop: 'snippet',
+    srsearch: term,
     srlimit: 15,
     list: 'search',
-    srsearch: term.replace(/:/g, ' '),
+
+    gsrsearch: term,
+    gsrnamespace: 0,
+    // gsrwhat: 'text',
+    // gsrinfo: '',
+    // gsrprop: 'redirecttitle',
+    // gsroffset: 0,
+    gsrlimit: 15,
+    piprop: 'thumbnail',
+    pithumbsize: 64,
+    pilimit: 15,
+
     format: 'json'
   }
 
@@ -36,11 +50,12 @@ export const search = (lang, term) => {
     }
     // data.query.search.sort((a, b) => a.index - b.index)
     return Object.values(data.query.search).map((p) => {
+      const page = data.query.pages.find(page => page.pageid === p.pageid)
       return {
         title: p.title,
         titleHtml: p.title,
-        description: p.snippet.replaceAll(/<span class="searchmatch">(\w+)<\/span>/g, '$1')
-        // imageUrl: p.thumbnail && p.thumbnail.source
+        description: p.snippet.replace(/<span class="searchmatch">(\w+)<\/span>/g, '$1'),
+        imageUrl: page && page.thumbnail && page.thumbnail.source
       }
     })
   })

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -4,20 +4,20 @@ export const search = (lang, term) => {
   // fulltext search
   const params = {
     action: 'query',
-    prop: 'pageimages',
-    generator: 'search',
     list: 'search',
     srprop: 'snippet',
     srsearch: term,
     srlimit: 15,
     srenablerewrites: true,
     srinfo: 'rewrittenquery',
-    gsrsearch: term,
-    gsrnamespace: 0,
-    gsrlimit: 15,
+    prop: 'pageimages',
     piprop: 'thumbnail',
     pithumbsize: 64,
     pilimit: 15,
+    generator: 'search',
+    gsrsearch: term,
+    gsrnamespace: 0,
+    gsrlimit: 15,
     format: 'json'
   }
 
@@ -27,12 +27,11 @@ export const search = (lang, term) => {
       return []
     }
 
-    return Object.values(data.query.search).map((p) => {
-      const page = data.query.pages.find(page => page.pageid === p.pageid)
+    return Object.values(data.query.search).map(item => {
+      const page = data.query.pages.find(page => page.pageid === item.pageid)
       return {
-        title: p.title,
-        titleHtml: p.title,
-        description: p.snippet.replace(/<span class="searchmatch">(\w+)<\/span>/g, '$1'),
+        title: item.title,
+        description: item.snippet.replace(/<span class="searchmatch">(\w+)<\/span>/g, '$1'),
         imageUrl: page && page.thumbnail && page.thumbnail.source
       }
     })

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -29,7 +29,6 @@ export const search = (lang, term) => {
     srsearch: term,
     srlimit: 15,
     srenablerewrites: true,
-    srinterwiki: true,
     gsrsearch: term,
     gsrnamespace: 0,
     gsrlimit: 15,

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -1,6 +1,8 @@
 import { cachedFetch, buildMwApiUrl } from 'utils'
 
 export const search = (lang, term) => {
+  // prefix search
+  /*
   const params = {
     action: 'query',
     prop: ['description', 'pageimages', 'pageprops'].join('|'),
@@ -14,18 +16,31 @@ export const search = (lang, term) => {
     gpsnamespace: 0,
     gpssearch: term.replace(/:/g, ' ')
   }
+  */
+
+  // fulltext search
+  // https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=no%20result%20page&format=json
+  const params = {
+    action: 'query',
+    srprop: 'snippet',
+    srlimit: 15,
+    list: 'search',
+    srsearch: term.replace(/:/g, ' '),
+    format: 'json'
+  }
+
   const url = buildMwApiUrl(lang, params)
   return cachedFetch(url, data => {
-    if (!data.query || !data.query.pages) {
+    if (!data.query || !data.query.search) {
       return []
     }
-    data.query.pages.sort((a, b) => a.index - b.index)
-    return Object.values(data.query.pages).map((p) => {
+    // data.query.search.sort((a, b) => a.index - b.index)
+    return Object.values(data.query.search).map((p) => {
       return {
         title: p.title,
-        titleHtml: p.title.replace(term, `<span class="searchmatch">${term}</span>`),
-        description: p.description,
-        imageUrl: p.thumbnail && p.thumbnail.source
+        titleHtml: p.title,
+        description: p.snippet.replaceAll(/<span class="searchmatch">(\w+)<\/span>/g, '$1')
+        // imageUrl: p.thumbnail && p.thumbnail.source
       }
     })
   })

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -1,25 +1,7 @@
 import { cachedFetch, buildMwApiUrl } from 'utils'
 
 export const search = (lang, term) => {
-  // prefix search
-  /*
-  const params = {
-    action: 'query',
-    prop: ['description', 'pageimages', 'pageprops'].join('|'),
-    piprop: 'thumbnail',
-    pilimit: 15,
-    ppprop: 'displaytitle',
-    generator: 'prefixsearch',
-    redirects: true,
-    pithumbsize: 64,
-    gpslimit: 15,
-    gpsnamespace: 0,
-    gpssearch: term.replace(/:/g, ' ')
-  }
-  */
-
   // fulltext search
-  // https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=no%20result%20page&format=json
   const params = {
     action: 'query',
     prop: 'pageimages',
@@ -29,6 +11,7 @@ export const search = (lang, term) => {
     srsearch: term,
     srlimit: 15,
     srenablerewrites: true,
+    srinfo: 'rewrittenquery',
     gsrsearch: term,
     gsrnamespace: 0,
     gsrlimit: 15,
@@ -43,7 +26,7 @@ export const search = (lang, term) => {
     if (!data.query || !data.query.search) {
       return []
     }
-    // data.query.search.sort((a, b) => a.index - b.index)
+
     return Object.values(data.query.search).map((p) => {
       const page = data.query.pages.find(page => page.pageid === p.pageid)
       return {

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -24,22 +24,18 @@ export const search = (lang, term) => {
     action: 'query',
     prop: 'pageimages',
     generator: 'search',
+    list: 'search',
     srprop: 'snippet',
     srsearch: term,
     srlimit: 15,
-    list: 'search',
-
+    srenablerewrites: true,
+    srinterwiki: true,
     gsrsearch: term,
     gsrnamespace: 0,
-    // gsrwhat: 'text',
-    // gsrinfo: '',
-    // gsrprop: 'redirecttitle',
-    // gsroffset: 0,
     gsrlimit: 15,
     piprop: 'thumbnail',
     pithumbsize: 64,
     pilimit: 15,
-
     format: 'json'
   }
 

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -31,7 +31,7 @@ export const search = (lang, term) => {
       const page = data.query.pages.find(page => page.pageid === item.pageid)
       return {
         title: item.title,
-        description: item.snippet.replace(/<span class="searchmatch">(\w+)<\/span>/g, '$1'),
+        description: item.snippet,
         imageUrl: page && page.thumbnail && page.thumbnail.source
       }
     })

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -14,7 +14,7 @@ export const ListView = ({ items = [], header, containerRef, empty }) => {
             <div class='item' dir={item.dir} data-selectable data-title={item.title} data-selected-key={item.title} key={item.title}>
               <div class='info'>
                 <bdi class='title' dangerouslySetInnerHTML={{ __html: item.displayTitle || item.title }} />
-                { item.description && <bdi class='description'>{item.description}</bdi> }
+                { item.description && <bdi class='description' dangerouslySetInnerHTML={{ __html: item.description }} /> }
               </div>
               { item.imageUrl && <div class='img' style={{ backgroundImage: `url(${item.imageUrl})` }} /> }
               { item.link && <div class='link'><img src='/images/link.svg' /></div> }


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T268751

### Problem Statement

During search, prefix search always return empty result

### Solution

use fulltext search instead

### Note

well, I can't tell wether the result is better, and <s>can't find the correct prop to return thumbnail</s> ios related code https://github.com/wikimedia/wikipedia-ios/blob/1bc0cea71e2556b60e8b30701e162318f737ffbb/Wikipedia/Code/WMFSearchFetcher.m#L77