### PR TITLE
Shorten Jio store version padding

### DIFF
--- a/scripts/manifest.js
+++ b/scripts/manifest.js
@@ -159,14 +159,12 @@ manifest.display = translations['en'].name
 manifest.subtitle = translations['en'].subtitle
 manifest.description = translations['en'].description
 
-const packageVersion = require('../package.json').version
-// The JioStore requires a 4-digit version (a.b.c.d). We append a
-// 4-digit long 4th digit because of the Jio version comparison algorithm.
-// It ignores the dots, concatenates all digits, and compare the resulting numbers.
-// Ex: 1.0.10.0 (10100) > 2.0.0.0 (2000)
-const jioVersionPadding = '.1000'
-manifest.version = packageVersion +
-	(process.env.TARGET_STORE === 'jio' ? jioVersionPadding : '')
+manifest.version = require('../package.json').version
+// The JioStore requires a 4-digit version (a.b.c.d) so we add
+// a non-significant 0 to it.
+if (process.env.TARGET_STORE === 'jio') {
+	manifest.version += '.0'
+}
 
 // Send output to stdout
 console.log(JSON.stringify(manifest, null, 2))


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

The JioStore has updated their version checking algorithm so that 1.2.0.0 > 1.0.0.1231 so we don't need a long (.1000) forth digit anymore.

### Solution

Use a single non-significant 0 as version padding.

### Note
