### PR TITLE
T271359: add undefined guard to isImageInGallery

### DIFF
--- a/src/hooks/useArticleLinksNavigation.js
+++ b/src/hooks/useArticleLinksNavigation.js
@@ -173,7 +173,7 @@ const findVisibleLinks = (container, galleryItems) => {
 
 const isImageInGallery = (galleryItems, link) => {
   const aElement = link.querySelector('a')
-  if (!aElement) {
+  if (!aElement || !galleryItems) {
     return false
   }
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T271359

### Objective

When an [article has no images](http://localhost:8080/#/article/fr/Veto), the gallery array is provided as an empty array (as opposed to `undefined`). The one case I can spot where `galleryItems` is provided to `useArticleLinksNavigation` as `undefined` is when invoked via `ReferencePreview`. I haven't found yet a specific example of a reference that replicates the issue, it would have to be a reference that contains a `figure` or `figure-inline` tag (is that even possible?). Also, the links navigation does not break for either `ReferencePreview` or `Article` as far as I can tell 

