### PR TITLE
T272484 style for listaref class

### DIFF
--- a/style/article.less
+++ b/style/article.less
@@ -228,6 +228,10 @@
 					margin: 10px;
 				}
 
+				.listaref {
+					all: inherit !important;
+				}
+
 				/* stylelint-disable */
 				#skip-to-top-button,
 				#skip-to-bottom-button {


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T272484

### Problem Statement

![image](https://user-images.githubusercontent.com/2560096/105182378-40938e00-5b2d-11eb-81e4-f55d904bedbb.png)

### Solution

![image](https://user-images.githubusercontent.com/2560096/105182415-49845f80-5b2d-11eb-95bd-a57344a3a935.png)

### Note

page

`es/Elecciones_presidenciales_de_Estados_Unidos_de_2020/Referencias`