### PR TITLE
Trim search query to prevent searching for empty string

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -21,7 +21,7 @@ export const Search = () => {
   const [query, setQuery, searchResults] = useSearch(lang)
   const isOnline = useOnlineStatus(online => {
     if (online) {
-      setQuery(inputRef.current.value)
+      setQuery(inputRef.current.value.trim())
     }
   })
   const onKeyCenter = () => {
@@ -33,7 +33,7 @@ export const Search = () => {
 
   const onInput = ({ target }) => {
     if (isOnline) {
-      setQuery(target.value)
+      setQuery(target.value.trim())
     }
   }
 

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -21,7 +21,7 @@ export const Search = () => {
   const [query, setQuery, searchResults] = useSearch(lang)
   const isOnline = useOnlineStatus(online => {
     if (online) {
-      setQuery(inputRef.current.value.trim())
+      setQuery(inputRef.current.value)
     }
   })
   const onKeyCenter = () => {
@@ -33,7 +33,7 @@ export const Search = () => {
 
   const onInput = ({ target }) => {
     if (isOnline) {
-      setQuery(target.value.trim())
+      setQuery(target.value)
     }
   }
 

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -8,7 +8,7 @@ export const useSearch = (lang) => {
   const [searchResults, setSearchResults] = useState()
 
   useEffect(() => {
-    if (query) {
+    if (query && query.trim()) {
       const [request, abort] = search(lang, query)
       request.then(setSearchResults)
       return abort


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T272276

### Problem Statement

Searching for empty string returns no results

### Solution

Trim the search query and only search if it is not empty

### Note
