### PR TITLE
Remove unneeded topics feed API and utils

### DIFF
--- a/src/api/getExperimentArticles.js
+++ b/src/api/getExperimentArticles.js
@@ -31,7 +31,3 @@ const getExperimentData = (prefix, lang) => {
 export const getTrendingArticles = lang => {
   return getExperimentData('Wikipedia_for_KaiOS/engagement1/trending', lang)
 }
-
-export const getTopicsArticles = lang => {
-  return getExperimentData('Wikipedia_for_KaiOS/engagement1/topics', lang)
-}

--- a/src/utils/experiment.js
+++ b/src/utils/experiment.js
@@ -3,7 +3,6 @@ const GROUP_STORAGE_KEY = '2021-KaiOS-app-homepage-content-suggestions'
 const GROUPS = [
   'control',
   'trending-articles'
-  // 'curated-topics'
 ]
 
 const getRandomGroupNumber = () => {
@@ -33,5 +32,3 @@ export const getExperiment = () => {
 }
 
 export const isTrendingArticlesGroup = () => getGroup() === GROUPS[1]
-
-export const isCuratedTopicsGroup = () => getGroup() === GROUPS[2]


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T271910

### Problem Statement

API and utils related to the topics feed are not needed anymore.

### Solution

Remove the API and utils related to the topics feed.

### Note
