### PR TITLE
Show gallery arrows in simulator

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -115,12 +115,12 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang, dir }) =>
     <div class='gallery-view' ref={containerRef}>
       {
         currentIndex !== 0 && (
-          <div class={`arrow ${dir === 'rtl' ? 'right' : 'left'}`} />
+          <img src='images/arrow.svg' class={`arrow ${dir === 'rtl' ? 'right' : 'left'}`} />
         )
       }
       {
         currentIndex < items.length - 1 && (
-          <div class={`arrow ${dir === 'rtl' ? 'left' : 'right'}`} />
+          <img src='images/arrow.svg' class={`arrow ${dir === 'rtl' ? 'left' : 'right'}`} />
         )
       }
       <div class='img'>

--- a/style/gallery.less
+++ b/style/gallery.less
@@ -20,7 +20,6 @@
 		top: calc( 50% - 10px );
 		width: 28px;
 		height: 28px;
-		background-image: url( /images/arrow.svg );
 
 		&.left {
 			left: 8px;
@@ -35,21 +34,19 @@
 	&.portrait {
 		.img {
 			height: @availableHeight; // Required under portrait for black background to work on device
-		}
-
-		img {
-			height: 100%;
-			width: auto;
+			img {
+				height: 100%;
+				width: auto;
+			}
 		}
 	}
 
 	&.landscape {
 		.img {
 			height: @availableHeight; // Required under landscape for black background to work on device
-		}
-
-		img {
-			max-width: 100%;
+			img {
+				max-width: 100%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

The gallery left/right arrows are not visible in the simulator because they are set in CSS with an absolute path.

### Solution

Change the arrows from div with background image to img with src and relative path so they are visible in the simulator.

### Note
