### PR TITLE
Trim the search terms

### DIFF
--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -11,7 +11,7 @@ export const useSearch = (lang) => {
   useEffect(() => {
     if (query && query.trim()) {
       setLoading(true)
-      const [request, abort] = search(lang, query)
+      const [request, abort] = search(lang, query.trim())
       request.then(data => {
         setLoading(false)
         setSearchResults(data)


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T272276

### Problem Statement

After typing a character, additional spaces trigger new search queries.

### Solution

Trim the search terms so that equivalent search queries are returned from the cache.

### Note
