### PR TITLE
Deploy the app and simulator for all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Deploy sim
           command: |
-            gh-pages --dist ./gh-pages --dotfiles -m "[ci skip] Update simulator"
+            gh-pages --dotfiles --dist ./gh-pages --dest $CIRCLE_BRANCH
 workflows:
   version: 2
   build:
@@ -67,6 +67,3 @@ workflows:
       - update-sim:
           requires:
             - build
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Deploy sim
           command: |
-            gh-pages --dotfiles --dist ./gh-pages --dest $CIRCLE_BRANCH -m "[ci skip] Update simulator"
+            gh-pages --dotfiles --dist ./gh-pages --dest $SIM_DIR -m "[ci skip] Update simulator"
 workflows:
   version: 2
   build:
@@ -67,3 +67,16 @@ workflows:
       - update-sim:
           requires:
             - build
+          filters:
+            branches:
+              only: master
+          environment:
+            SIM_DIR: "."
+      - update-sim:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: master
+          environment:
+            SIM_DIR: $CIRCLE_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - run:
           name: Deploy sim
           command: |
-            gh-pages --dotfiles --dist ./gh-pages --dest $SIM_DIR -m "[ci skip] Update simulator"
+            gh-pages --dotfiles --add --dist ./gh-pages --dest $CIRCLE_BRANCH -m "[ci skip] Update simulator"
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,11 @@ jobs:
             git config user.email "ci-build@wikimedia.org"
             git config user.name "ci-build"
       - run:
+        name: SEt gh-pages dest based on current branch
+        command: |
+          echo 'export SIM_DIR=$([ "$CIRCLE_BRANCH" == "master" ] && echo "." || echo "$CIRCLE_BRANCH")' >> $BASH_ENV
+          source $BASH_ENV
+      - run:
           name: Deploy sim
           command: |
             gh-pages --dotfiles --dist ./gh-pages --dest $SIM_DIR -m "[ci skip] Update simulator"
@@ -67,16 +72,3 @@ workflows:
       - update-sim:
           requires:
             - build
-          filters:
-            branches:
-              only: master
-          environment:
-            SIM_DIR: "."
-      - update-sim:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: master
-          environment:
-            SIM_DIR: $CIRCLE_BRANCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Set gh-pages dest based on current branch
           command: |
-            echo 'export SIM_DIR=$([ "$CIRCLE_BRANCH" == "sim-all-branches" ] && echo "success" || echo "$CIRCLE_BRANCH")' >> $BASH_ENV
+            echo 'export SIM_DIR=$([ "$CIRCLE_BRANCH" == "master" ] && echo "." || echo "$CIRCLE_BRANCH")' >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: Deploy sim

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Deploy sim
           command: |
-            gh-pages --dotfiles --dist ./gh-pages --dest $CIRCLE_BRANCH
+            gh-pages --dotfiles --dist ./gh-pages --dest $CIRCLE_BRANCH -m "[ci skip] Update simulator"
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,10 @@ jobs:
             git config user.email "ci-build@wikimedia.org"
             git config user.name "ci-build"
       - run:
-        name: SEt gh-pages dest based on current branch
-        command: |
-          echo 'export SIM_DIR=$([ "$CIRCLE_BRANCH" == "master" ] && echo "." || echo "$CIRCLE_BRANCH")' >> $BASH_ENV
-          source $BASH_ENV
+          name: Set gh-pages dest based on current branch
+          command: |
+            echo 'export SIM_DIR=$([ "$CIRCLE_BRANCH" == "master" ] && echo "." || echo "$CIRCLE_BRANCH")' >> $BASH_ENV
+            source $BASH_ENV
       - run:
           name: Deploy sim
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Set gh-pages dest based on current branch
           command: |
-            echo 'export SIM_DIR=$([ "$CIRCLE_BRANCH" == "master" ] && echo "." || echo "$CIRCLE_BRANCH")' >> $BASH_ENV
+            echo 'export SIM_DIR=$([ "$CIRCLE_BRANCH" == "sim-all-branches" ] && echo "success" || echo "$CIRCLE_BRANCH")' >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: Deploy sim


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

Wouldn't it be nice to be able to test any branch in the simulator without downloading the code?

### Solution

Deploy every branch to gh-pages

Example: https://wikimedia.github.io/wikipedia-kaios/sim-all-branches/sim.html

### Note

There is no automated way to clean up the old branch directories after they are deleted, I'll clean them up manually once in a while.
