### PR TITLE
Don't show Feed component when it is not available

### DIFF
--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -21,10 +21,10 @@ export const Feed = ({ lang, isExpanded, setIsExpanded, lastIndex, setNavigation
     }
   }, [trendingArticles])
 
-  return (
+  return trendingArticles.length ? (
     <div class={`feed ${isExpanded ? 'expanded' : 'collapsed'}`}>
       {!isExpanded && <div class='cue' />}
       <ListView items={trendingArticles} header={i18n('feed-header')} containerRef={containerRef} />
     </div>
-  )
+  ) : null
 }


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

It shows empty feed component 

### Solution

hide it

### Note

tested on https://wikimedia.github.io/wikipedia-kaios/T275621-experiment-config/sim.html to see empty feed component