### PR TITLE
Put main.js back in the dist folder

### DIFF
--- a/scripts/zip.sh
+++ b/scripts/zip.sh
@@ -7,11 +7,11 @@ rm -rf Wikipedia
 rm -rf dist
 rm $FILENAME.zip
 
-mkdir Wikipedia
+mkdir -p Wikipedia/dist
 
 TARGET_STORE=$TARGET node scripts/manifest.js > Wikipedia/manifest.webapp
 TARGET_STORE=$TARGET INSTRUMENTATION=1 MANIFEST_FILE=./Wikipedia/manifest.webapp npm run build
-cp dist/main.js Wikipedia/
+cp dist/main.js Wikipedia/dist/main.js
 cp -r images Wikipedia/
 cp index.html Wikipedia/
 


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

When configuring the source-map for debugging in #307, I accidentally changed the bundling to have main.js at the root of the zip instead of in the dist folder. That breaks the bundle.

### Solution

Put main.js back in the dist folder in the application bundle (zip).

### Note
