### PR TITLE
T271904: minor followup 

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -46,6 +46,7 @@ export const Search = () => {
   const onKeyBackSpace = () => {
     if (isFeedExpanded) {
       setIsFeedExpanded(false)
+      setLastFeedIndex(null)
       listRef.current.scrollTop = 0
       setNavigation(0)
     } else {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T271904

This is just a minor followup to #322, I ran into this little bug today.

### Problem

If you expand the feed and click on some article, then go back to `Search`, you will land on the feed with that last index selected, as requested by design. No issues there. If you then hit backspace, and then go to `Settings`, and then hit backspace again: you land on the expanded feed again, when it should be collapsed instead.

### Solution

 We should also reset `lastFeedIndex` within `onKeyBackSpace` because that's a valid way to collapse the feed (besides `onKeyArrowUp`).

