### PR TITLE
Add cypress dashboard

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     "no-only-tests"
   ],
   "rules": {
-    "no-only-tests/no-only-tests": "error"
+    "no-only-tests/no-only-tests": "error",
+    "cypress/no-unnecessary-waiting": "warn"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![wikipedia-kaios](https://img.shields.io/endpoint?url=https://dashboard.cypress.io/badge/detailed/7izdto&style=flat&logo=cypress)](https://dashboard.cypress.io/projects/7izdto/runs)
 [![CircleCI](https://circleci.com/gh/wikimedia/wikipedia-kaios/tree/master.svg?style=svg)](https://circleci.com/gh/wikimedia/wikipedia-kaios/tree/master)
 
 # Wikipedia KaiOS 

--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,6 @@
     "videoUploadOnPasses": false,
     "modifyObstructiveCode": false,
     "baseUrl": "http://127.0.0.1:8080",
-    "retries": 5
+    "retries": 5,
+    "defaultCommandTimeout": 8000
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,8 @@
-{  
-    "viewportWidth": 240,
-    "viewportHeight": 290,
-    "baseUrl": "http://127.0.0.1:8080",
-    "retries": 5,
-    "defaultCommandTimeout": 8000
+{
+  "viewportWidth": 240,
+  "viewportHeight": 290,
+  "videoUploadOnPasses": false,
+  "baseUrl": "http://127.0.0.1:8080",
+  "retries": 5,
+  "defaultCommandTimeout": 8000
 }

--- a/cypress.json
+++ b/cypress.json
@@ -4,6 +4,5 @@
     "videoUploadOnPasses": false,
     "modifyObstructiveCode": false,
     "baseUrl": "http://127.0.0.1:8080",
-    "video": false,
     "retries": 5
 }

--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,5 @@
     "modifyObstructiveCode": false,
     "baseUrl": "http://127.0.0.1:8080",
     "video": false,
-    "retries": 3
+    "retries": 5
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,8 +1,6 @@
 {  
     "viewportWidth": 240,
     "viewportHeight": 290,
-    "videoUploadOnPasses": false,
-    "modifyObstructiveCode": false,
     "baseUrl": "http://127.0.0.1:8080",
     "retries": 5,
     "defaultCommandTimeout": 8000

--- a/cypress/integration/search-spec.js
+++ b/cypress/integration/search-spec.js
@@ -60,6 +60,7 @@ describe('Article search', () => {
     searchPage.search('cat')
     cy.getCenterSoftkeyButton().should('not.have.text')
     searchPage.results().first()
+    cy.wait(500)
     cy.downArrow()
     cy.getCenterSoftkeyButton().should('have.text', enJson['centerkey-select'])
     cy.upArrow()

--- a/cypress/integration/special-cases.js
+++ b/cypress/integration/special-cases.js
@@ -22,6 +22,7 @@ describe('special cases tests', () => {
 
   it('gallery opens from a non-english article', () => {
     cy.navigateToPageWithoutOnboarding('article/pl/Tupolew_Tu-154/Użytkownicy[24]')
+    cy.wait(500)
     articlePage.title().should('have.text', 'Użytkownicy[24]')
     cy.rightArrow()
     cy.enter()

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cypress:fix-lint": "eslint cypress/ --fix",
     "cypress:run": "cypress run",
     "cypress:run:firefox": "cypress run --browser firefox",
-    "cypress:run:firefox:headless": "cypress run --browser firefox --headless",
+    "cypress:run:firefox:headless": "cypress run --browser firefox --headless --record --key $CYPRESS_RECORD_KEY",
     "cypress:open": "cypress open"
   },
   "repository": {


### PR DESCRIPTION
Add access to cypress dashboard

https://dashboard.cypress.io/projects/7izdto/runs

Super handy to trackdown flaky tests and to get an overview of our tests and metrics.

Also added a badge to the README that shows the test run status and numbers.

Also added test retries that hopefully makes our builds more reliable in case we have a flaky test.
