### PR TITLE
Harden experiment config

### DIFF
--- a/src/api/getExperimentConfig.js
+++ b/src/api/getExperimentConfig.js
@@ -16,6 +16,11 @@ export const getExperimentConfig = () => {
     if (page.missing) {
       return {}
     }
-    return JSON.parse(page.revisions[0].slots.main.content)
+    try {
+      return JSON.parse(page.revisions[0].slots.main.content)
+    } catch (e) {
+      console.warn('Error fetching the experiment config', e, JSON.stringify(data))
+      return {}
+    }
   })
 }


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

We've seen the fetching of the experiment config fail from time to time in CI with "page.revisions is undefined". Wondering whaat's up with that.

### Solution

Log a warning with the content of the API response when this happens.

### Note

I hope this is temporary.
