### PR TITLE
Device screen height is 290px (320px - 30px (top bar))

### DIFF
--- a/sim.html
+++ b/sim.html
@@ -116,7 +116,7 @@
 				top: 40px;
 				left: 10px;
 				width: 240px;
-				height: 310px;
+				height: 290px;
 				cursor: not-allowed;
 			}
 			.keyselector {
@@ -141,7 +141,7 @@
 			}
 			#appFrame {
 				width: 240px;
-				height: 310px;
+				height: 290px;
 				border: 0;
 			}
 			.brand {


### PR DESCRIPTION
Make the sim screen the same size as a known device (banana phone).