### PR TITLE
Error logging: use ?hasty param in prod

### DIFF
--- a/src/utils/sendErrorLog.js
+++ b/src/utils/sendErrorLog.js
@@ -1,6 +1,6 @@
-import { appVersion, gitHash } from 'utils'
+import { appVersion, gitHash, isProd } from 'utils'
 
-const intakeUrl = 'https://intake-logging.wikimedia.org/v1/events'
+const intakeUrl = 'https://intake-logging.wikimedia.org/v1/events' + (isProd() ? '?hasty=true' : '')
 
 export const sendErrorLog = ({ message, stack = '', url = '' }) => {
   navigator.sendBeacon(intakeUrl, JSON.stringify({


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

Without the `hasty` param the server will validate the schema before returning. It's great for development for we have a change to notice if we're sending invalid events but for production it's better to make it hasty.

### Solution

Add the `hasty` param in production

### Note

Sim Link: https://wikimedia.github.io/wikipedia-kaios/<BRANCH NAME>/sim.html
