### PR TITLE
disable scrolling for simulator

### DIFF
--- a/sim.html
+++ b/sim.html
@@ -27,7 +27,7 @@
 					<div>c</div>
 				</div>
 			</div>
-			<iframe id="appFrame" src="./"></iframe>
+			<iframe id="appFrame" src="./" scrolling="no"></iframe>
 			<div class="brand">INUKA</div>
 			<table class="keypad">
 				<tr>


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

iframe scrollbar annoying in Windows

### Solution

hides the scrollbar used by iframe

Before / After
![image](https://user-images.githubusercontent.com/2560096/111666465-0801ef00-8814-11eb-9ee0-62bd89100a3d.png)

### Note

Sim Link: https://wikimedia.github.io/wikipedia-kaios/iframe-scrollbar-no/sim.html
