### PR TITLE
T277497: Add basic error handling for trending articles feed

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -98,6 +98,7 @@
     "about-app-message": "Made by the Wikimedia Foundation with the help of volunteers like you.",
     "softkey-read-more": "Read More",
     "feed-header": "Trending",
+    "feed-error-message": "Unable to load trending articles",
     "feedback-header": "Send feedback",
     "feedback-explanation": "We will use your feedback to help improve this app. Your response will be kept for 90 days, subject to our $1 and $2",
     "feedback-placeholder": "Start writing here...",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -100,6 +100,7 @@
 	"softkey-read-more": "Label of the read more softkey",
 	"feed-header": "Label for content suggestions feed header",
 	"feedback-header": "Header title shown in Feedback component, selected from Settings menu",
+	"feed-error-message": "The message when an feed articles cannot be loaded because of some error",
 	"feedback-explanation": "Message displained in Feedback component that explains how feedback information will be used. \n* $1 - Privacy policy hyperlink. \n* $2 - Terms of use hyperlink",
 	"feedback-placeholder": "Placeholder message shown in textarea of Feedback component",
 	"feedback-success": "Message shown upon successfully sending feedback message in Feedback component",

--- a/src/api/getTrendingArticles.js
+++ b/src/api/getTrendingArticles.js
@@ -13,7 +13,7 @@ export const getTrendingArticles = (lang, country) => {
   return cachedFetch(url, data => {
     const page = data.query.pages[0]
     if (page.missing) {
-      sendErrorLog({ message: page.title, url })
+      sendErrorLog({ message: `There was an issue fetching '${page.title}', the full API response is: ${JSON.stringify(data)}`, url })
       return []
     }
     return JSON.parse(page.revisions[0].slots.main.content)

--- a/src/api/getTrendingArticles.js
+++ b/src/api/getTrendingArticles.js
@@ -1,4 +1,4 @@
-import { buildMwOrgApiUrl, cachedFetch } from 'utils'
+import { buildMwOrgApiUrl, cachedFetch, sendErrorLog } from 'utils'
 
 export const getTrendingArticles = (lang, country) => {
   const title = `Wikipedia_for_KaiOS/engagement1/trending/${lang}/${country.toLowerCase()}`
@@ -13,6 +13,7 @@ export const getTrendingArticles = (lang, country) => {
   return cachedFetch(url, data => {
     const page = data.query.pages[0]
     if (page.missing) {
+      sendErrorLog({ message: page, url })
       return []
     }
     return JSON.parse(page.revisions[0].slots.main.content)

--- a/src/api/getTrendingArticles.js
+++ b/src/api/getTrendingArticles.js
@@ -13,7 +13,7 @@ export const getTrendingArticles = (lang, country) => {
   return cachedFetch(url, data => {
     const page = data.query.pages[0]
     if (page.missing) {
-      sendErrorLog({ message: page, url })
+      sendErrorLog({ message: page.title, url })
       return []
     }
     return JSON.parse(page.revisions[0].slots.main.content)

--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -34,11 +34,15 @@ export const Feed = ({ lang, isExpanded, setIsExpanded, lastIndex, setNavigation
     }
   }, [loading, isExpanded])
 
+  const showArticles = trendingArticles.length > 0 && !loading
+  const showError = trendingArticles.length === 0 && !loading
+
   return (
     <div class={`feed ${isExpanded ? 'expanded' : 'collapsed'}`}>
       {!isExpanded && <div class='cue' />}
-      {!loading && <ListView items={trendingArticles} header={i18n('feed-header')} containerRef={containerRef} />}
       {loading && <Loading isExpanded={isExpanded} />}
+      {showArticles && <ListView items={trendingArticles} header={i18n('feed-header')} containerRef={containerRef} />}
+      {showError && <Error />}
     </div>
   )
 }
@@ -70,6 +74,16 @@ const Loading = ({ isExpanded }) => {
     <div class='loading'>
       {!isExpanded && <div class='collapsed' />}
       {isExpanded && loadingExpanded()}
+    </div>
+  )
+}
+
+const Error = () => {
+  const i18n = useI18n()
+  return (
+    <div class='error'>
+      <img src='images/article-error.png' />
+      <p class='message' data-selectable>{i18n('feed-error-message')}</p>
     </div>
   )
 }

--- a/style/feed.less
+++ b/style/feed.less
@@ -195,4 +195,20 @@
 			}
 		}
 	}
+
+	.error {
+		background-color: #fff;
+		height: @availableHeight;
+		width: 100vw;
+		display: flex;
+		align-items: center;
+		justify-content: start;
+		flex-direction: column;
+		padding-top: 20px;
+
+		p {
+			font-size: @bigFont;
+			text-align: center;
+		}
+	}
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T277497

### Objective 

How should the app react when the api returns falsy/empty data. A potential solution is an error state to render in the feed UI, instead of just an empty feed (which is the current behavior).

We also need to we need to log it in our client-side errors stream (`sendErrorLog`)

### Note

Sim Link: https://wikimedia.github.io/wikipedia-kaios/T277497-feed-error/sim.html
