### PR TITLE
T278133: Display only the first 5 items in feed list

### DIFF
--- a/src/api/getTrendingArticles.js
+++ b/src/api/getTrendingArticles.js
@@ -15,6 +15,6 @@ export const getTrendingArticles = (lang, country) => {
     if (page.missing) {
       return []
     }
-    return JSON.parse(page.revisions[0].slots.main.content)
+    return JSON.parse(page.revisions[0].slots.main.content).slice(0, 5)
   })
 }

--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -37,7 +37,7 @@ export const Feed = ({ lang, isExpanded, setIsExpanded, lastIndex, setNavigation
   return (
     <div class={`feed ${isExpanded ? 'expanded' : 'collapsed'}`}>
       {!isExpanded && <div class='cue' />}
-      {!loading && <ListView items={trendingArticles} header={i18n('feed-header')} containerRef={containerRef} />}
+      {!loading && <ListView items={trendingArticles.slice(0, 5)} header={i18n('feed-header')} containerRef={containerRef} />}
       {loading && <Loading isExpanded={isExpanded} />}
     </div>
   )

--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -37,7 +37,7 @@ export const Feed = ({ lang, isExpanded, setIsExpanded, lastIndex, setNavigation
   return (
     <div class={`feed ${isExpanded ? 'expanded' : 'collapsed'}`}>
       {!isExpanded && <div class='cue' />}
-      {!loading && <ListView items={trendingArticles.slice(0, 5)} header={i18n('feed-header')} containerRef={containerRef} />}
+      {!loading && <ListView items={trendingArticles} header={i18n('feed-header')} containerRef={containerRef} />}
       {loading && <Loading isExpanded={isExpanded} />}
     </div>
   )


### PR DESCRIPTION
https://phabricator.wikimedia.org/T278133

## Objective

The list of trending articles fetched from mediawiki may contain more than 5 items but the app should only use the first 5.

### Note

Sim Link: https://wikimedia.github.io/wikipedia-kaios/T278133-feed-max/sim.html
