### PR TITLE
T271677: Remove setNavigation conflict

### DIFF
--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -25,14 +25,10 @@ export const Feed = ({ lang, isExpanded, setIsExpanded, lastIndex, setNavigation
     if (lastIndex) {
       setIsExpanded(true)
       setNavigation(lastIndex)
-    }
-  }, [trendingArticles])
-
-  useEffect(() => {
-    if (isExpanded) {
+    } else if (isExpanded) {
       setNavigation(1)
     }
-  }, [loading, isExpanded])
+  }, [trendingArticles, loading, isExpanded])
 
   return (
     <div class={`feed ${isExpanded ? 'expanded' : 'collapsed'}`}>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -31,18 +31,34 @@ export const Search = () => {
       setQuery(inputRef.current.value)
     }
   })
+
+  const handleLastFeedIndex = () => {
+    const { index } = getCurrent()
+    if (index && isFeedExpanded) {
+      setLastFeedIndex(index)
+    }
+  }
+
   const onKeyCenter = () => {
     if (allowUsage()) {
       const { index, key } = getCurrent()
-      if (index && isFeedExpanded) {
-        setLastFeedIndex(index)
-      }
+      handleLastFeedIndex()
       if (index) {
         goto.article(lang, key)
       } else if (isRandomEnabled() && !query) {
         goToRandomArticle()
       }
     }
+  }
+
+  const onKeyRight = () => {
+    handleLastFeedIndex()
+    goto.settings()
+  }
+
+  const onKeyLeft = () => {
+    handleLastFeedIndex()
+    goto.tips()
   }
 
   const onKeyBackSpace = () => {
@@ -112,11 +128,11 @@ export const Search = () => {
 
   useSoftkey('Search', {
     right: allowUsage() ? i18n('softkey-settings') : '',
-    onKeyRight: allowUsage() ? goto.settings : null,
+    onKeyRight: allowUsage() ? onKeyRight : null,
     center: current.type === 'DIV' ? i18n('centerkey-select') : '',
     onKeyCenter,
     left: allowUsage() ? i18n('softkey-tips') : '',
-    onKeyLeft: allowUsage() ? goto.tips : null,
+    onKeyLeft: allowUsage() ? onKeyLeft : null,
     onKeyBackspace: !(query && current.type === 'INPUT') && onKeyBackSpace,
     onKeyArrowDown: !loading && onKeyArrowDown,
     onKeyArrowUp: !loading && onKeyArrowUp


### PR DESCRIPTION
https://phabricator.wikimedia.org/T271677

### Problem Statement

Huei found this bug: if user selects an article from trending feed and then hits `backspace` to return to the feed, the `lastIndex` item is not rendered as selected (and instead the first item is highlighted 🐛). This is because a `setNavigation(1)` from a second `useEffect` is overriding the navigation logic for when the user returns from article. This bug was introduced in #337. 

### Solution

We can actually simplify the `useEffect` calls into one because they actually perform similar/complementary logic with `setNavigation`. The dependencies observed remain the same (`trendingArticles`, `loading`, `isExpanded`)

### Note

Sim Link: https://wikimedia.github.io/wikipedia-kaios/T271677-feed-loading-followup-lastIndex-bug/sim.html
