### PR TITLE
T277497: Guard for undefined page

### DIFF
--- a/src/api/getTrendingArticles.js
+++ b/src/api/getTrendingArticles.js
@@ -12,7 +12,7 @@ export const getTrendingArticles = (lang, country) => {
   const url = buildMwOrgApiUrl(params)
   return cachedFetch(url, data => {
     const page = data.query.pages[0]
-    if (page.missing) {
+    if (page && page.missing) {
       sendErrorLog({ message: `There was an issue fetching '${page.title}', the full API response is: ${JSON.stringify(data)}`, url })
       return []
     }


### PR DESCRIPTION
### Objective

QA brought up if for whatever reason the response of `getTrendingArticles` comes back with `data.query.pages[0]` as `undefined`, a `TypeError` is thrown. This adds a guard against that. 

See https://phabricator.wikimedia.org/T277497#7038271 for more