### PR TITLE
Convert lang code nb to no for Norwegian (Bokmal)

### DIFF
--- a/src/api/getLanglinks.js
+++ b/src/api/getLanglinks.js
@@ -4,9 +4,11 @@ import {
   isPrioritized
 } from 'utils'
 
-const convertToWikiLang = lang => {
-  // The lang link endpoint return 'nb' but the wiki subdomain is 'no'
-  return lang === 'nb' ? 'no' : lang
+const getLangFromUrl = url => {
+  // Get the lang code from the site URL since it may differ from
+  // the official code used in configuration.
+  const prefixLength = 'https://'.length
+  return url.substr(prefixLength, url.indexOf('.') - prefixLength)
 }
 
 export const getLanglinks = (lang, title) => {
@@ -15,7 +17,7 @@ export const getLanglinks = (lang, title) => {
     titles: title,
     prop: 'langlinks',
     lllimit: 500,
-    llprop: 'langname|autonym'
+    llprop: 'langname|autonym|url'
   }
   const url = buildMwApiUrl(lang, params)
   return cachedFetch(url, response => {
@@ -26,7 +28,7 @@ export const getLanglinks = (lang, title) => {
         return {
           title: item.autonym,
           langname: item.langname,
-          lang: convertToWikiLang(item.lang),
+          lang: getLangFromUrl(item.url),
           description: item.title,
           dir: getDirection(item.lang)
         }

--- a/src/utils/languages.js
+++ b/src/utils/languages.js
@@ -1504,8 +1504,10 @@ const prioritizedLists = {
   jio: ['en', 'hi', 'ji', 'as', 'bn', 'gu', 'kn', 'ks', 'ml', 'mr', 'ne', 'or', 'pa', 'sa', 'sd', 'ta', 'te', 'und', 'mai', 'kok', 'mni', 'doi', 'ur']
 }
 
-export const prioritizedList = prioritizedLists[prioritizedLanguageListName] ||
+const prioritizedList = prioritizedLists[prioritizedLanguageListName] ||
       prioritizedLists.default
+
+export const isPrioritized = lang => prioritizedList.indexOf(lang) > -1
 
 export const getDirection = langCode => {
   return rtl.includes(langCode) ? 'rtl' : 'ltr'


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T280274

### Problem Statement

The langlinks API returns the language code 'nb' for Norwegian (Bokmal) but Wikipedia uses 'no' as the subdomain. 

### Solution

Convert the API response from 'nb' to 'no'

To test, I used `en/Earth`, then use the language button to switch to `no/Jorden`

### Note

Sim Link: https://wikimedia.github.io/wikipedia-kaios/no-nb/sim.html
