### PR TITLE
Print only the relevant memory stats

### DIFF
--- a/scripts/stats_header.sh
+++ b/scripts/stats_header.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# USS and PSS are the important columns for memory usage analysis
-echo 'TIME NAME PID PPID CPU(s) NICE USS PSS RSS SWAP VSIZE ADJ SCORE_ADJ USER'
+echo 'TIME USS PSS'

--- a/scripts/stats_line.sh
+++ b/scripts/stats_line.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 DATE=`date "+%H:%M:%S"`
-LINE=`adb shell b2g-info | grep Wikipedia | sed -E 's/ +/ /g' | sed -E 's/^ //'`
+LINE=`adb shell b2g-info | grep Wikipedia | sed -E 's/ +/ /g' | sed -E 's/^ //' | cut -d' ' -f6,7`
 echo $DATE $LINE
 $0


### PR DESCRIPTION
Phabricator Link: -

### Problem Statement

The stats script prints a bunch of columns and it hard to know which ones are relevant

### Solution

Print only the USS and PSS columns so it's easier to troubleshoot memory usage.

### Note

Sim Link: Not relevant
