### PR TITLE
Fix Gallery/About

### DIFF
--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -109,7 +109,7 @@ export const Gallery = ({ close, closeAll, items, startFileName, lang, dir }) =>
     [dir === 'rtl' ? 'onKeyFixedArrowLeft' : 'onKeyFixedArrowRight']: onNextImage,
     [dir === 'rtl' ? 'onKeyFixedArrowRight' : 'onKeyFixedArrowLeft']: onPrevImage,
     onKeyBackspace: close
-  }, [currentIndex])
+  }, [currentIndex, mediaInfo])
 
   return (
     <div class='gallery-view' ref={containerRef}>


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/T286725

### Problem Statement

Follow-up to #372 
The gallery/about feature doesn't have access to the media info and stays in loading state.

### Solution

Add `mediaInfo` as a softkey dependency so that the handlers are updated when the media info becomes available.

### Note

Sim Link: https://wikimedia.github.io/wikipedia-kaios/mediaInfo/sim.html
