### PR TITLE
Add EndCall key to Search.js and remove Global EndCall handler

### DIFF
--- a/cypress/integration/search-spec.js
+++ b/cypress/integration/search-spec.js
@@ -50,6 +50,22 @@ describe('Article search', () => {
       .children().first().next().should('have.class', 'img')
   })
 
+  it('back button should take us to home page', () => {
+    cy.intercept('/api.php', { fixture: 'cattle-search.json' })
+    searchPage.search('cattle')
+    cy.downArrow()
+    cy.backspace()
+    cy.get('.listview').should('not.exist')
+  })
+
+  it('back button should take us to home page', () => {
+    cy.intercept('/api.php', { fixture: 'cattle-search.json' })
+    searchPage.search('cattle')
+    cy.downArrow()
+    cy.endCall()
+    cy.get('.listview').should('not.exist')
+  })
+
   it('should show empty result found when search for "adf23cv111111"', () => {
     searchPage.search('adf23cv111111')
     searchPage.getEmptyContent().should('have.text', enJson['no-result-found'])

--- a/cypress/integration/search-spec.js
+++ b/cypress/integration/search-spec.js
@@ -58,7 +58,7 @@ describe('Article search', () => {
     cy.get('.listview').should('not.exist')
   })
 
-  it('back button should take us to home page', () => {
+  it('end call button should take us to home page', () => {
     cy.intercept('/api.php', { fixture: 'cattle-search.json' })
     searchPage.search('cattle')
     cy.downArrow()

--- a/cypress/integration/search-spec.js
+++ b/cypress/integration/search-spec.js
@@ -62,7 +62,7 @@ describe('Article search', () => {
     cy.intercept('/api.php', { fixture: 'cattle-search.json' })
     searchPage.search('cattle')
     cy.downArrow()
-    cy.endCall()
+    cy.pressEndCallButton()
     cy.get('.listview').should('not.exist')
   })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,6 +9,7 @@ import * as enJson from '../../i18n/en.json'
   'leftArrow',
   'rightArrow',
   'backspace',
+  'endCall',
   'enter'
 ].forEach((key) => {
   Cypress.Commands.add(key, (repeat = 1) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,7 +9,6 @@ import * as enJson from '../../i18n/en.json'
   'leftArrow',
   'rightArrow',
   'backspace',
-  'endCall',
   'enter'
 ].forEach((key) => {
   Cypress.Commands.add(key, (repeat = 1) => {
@@ -29,6 +28,16 @@ Cypress.Commands.add('getRightSoftkeyButton', () => {
 
 Cypress.Commands.add('getCenterSoftkeyButton', () => {
   return cy.get('.softkey > .center')
+})
+
+Cypress.Commands.add('pressEndCallButton', () => {
+  const endCallEvent = new KeyboardEvent('keydown', {
+    key: 'EndCall',
+    composed: true,
+    bubbles: true,
+    cancelable: false
+  })
+  document.dispatchEvent(endCallEvent)
 })
 
 Cypress.Commands.add('clickCloseButton', () => {

--- a/sim.html
+++ b/sim.html
@@ -60,7 +60,10 @@
 				<tr>
 					<td><div class="button largeicon call">&mdash;</div></td>
 					<td><div class="button sk" data-key="ArrowDown">&darr;</div></td>
-					<td><div class="button largeicon backspace" data-key="Backspace">&mdash;</div></td>
+					<td class="flex-td">
+						<div class="button backspace" data-key="Backspace">↩</div>
+						<div class="button endcall" data-key="EndCall">&mdash;</div>
+					</td>
 				</tr>
 				<tr>
 					<td><div class="button char" data-key="1">1 <span>.,?</span></div></td>
@@ -199,11 +202,21 @@
 			.button.backspace {
 				color: red;
 			}
+			.button.endcall {
+				color: red;
+			}
 			.button span {
 				font-size: 8px;
 			}
 			.controlpanel #online {
 				display: none;
+			}
+			.flex-td {
+				display: flex;
+			}
+			.flex-td .button {
+				flex: auto;
+				font-size: 15px;
 			}
 		</style>
 		<script type="text/javascript">
@@ -441,6 +454,7 @@
 			});
 
 			// Experiment Group for Trending Articles toggle
+			/* the experiment trending articles is now disabled
 			document.querySelector('#experiment-trending').addEventListener('mousedown', function(e) {
 				const input = document.getElementById('experiment-trending').querySelector('input')
 				const checked = !input.checked
@@ -454,6 +468,7 @@
 				input.checked = checked
 				appFrame.contentWindow.location = './'
 			});
+			*/
 
 			// navigator.sendBeacon may be undefined in some browser configuration
 			if (!appFrame.contentWindow.navigator.sendBeacon) {

--- a/sim.html
+++ b/sim.html
@@ -341,6 +341,15 @@
 				return $element.tagName === 'INPUT' || $element.tagName === 'TEXTAREA';
 			}
 
+			const simulateBackspace = function(element) {
+				if (element.value !== '' && element.selectionStart > 0) {
+					const v = element.value
+					const caret = element.selectionStart - 1
+					element.value = v.substring(0, caret) + v.substring(caret + 1)
+					element.setSelectionRange(caret, caret)
+					element.dispatchEvent(new InputEvent('input'))
+				}
+			}
 			const keyHandlers = {
 				'.button.sk': function(e) {
 					dispatchKeyToDoc(e.currentTarget.getAttribute('data-key'));
@@ -348,15 +357,17 @@
 				'.button.backspace': function(e) {
 					const element = appFrame.contentDocument.activeElement;
 					if (isInput(element)) {
-						if (element.value !== '' && element.selectionStart > 0) {
-							const v = element.value
-							const caret = element.selectionStart - 1
-							element.value = v.substring(0, caret) + v.substring(caret + 1)
-							element.setSelectionRange(caret, caret)
-							element.dispatchEvent(new InputEvent('input'))
-						}
+						simulateBackspace(element);
 					} else {
 						dispatchKeyToDoc('Backspace')
+					}
+				},
+				'.button.endcall': function(e) {
+					const element = appFrame.contentDocument.activeElement;
+					if (isInput(element)) {
+						simulateBackspace(element);
+					} else {
+						dispatchKeyToDoc('EndCall')
 					}
 				},
 				'.button.lr': function(e) {

--- a/sim.html
+++ b/sim.html
@@ -357,11 +357,13 @@
 				'.button.backspace': function(e) {
 					const element = appFrame.contentDocument.activeElement;
 					if (isInput(element)) {
-						const v = element.value
-						const caret = element.selectionStart - 1
-						element.value = v.substring(0, caret) + v.substring(caret + 1)
-						element.setSelectionRange(caret, caret)
-						element.dispatchEvent(new InputEvent('input'))
+						if (element.value !== '' && element.selectionStart > 0) {
+							const v = element.value
+							const caret = element.selectionStart - 1
+							element.value = v.substring(0, caret) + v.substring(caret + 1)
+							element.setSelectionRange(caret, caret)
+							element.dispatchEvent(new InputEvent('input'))
+						}
 					} else {
 						dispatchKeyToDoc('Backspace')
 					}

--- a/sim.html
+++ b/sim.html
@@ -341,15 +341,6 @@
 				return $element.tagName === 'INPUT' || $element.tagName === 'TEXTAREA';
 			}
 
-			const simulateBackspace = function(element) {
-				if (element.value !== '' && element.selectionStart > 0) {
-					const v = element.value
-					const caret = element.selectionStart - 1
-					element.value = v.substring(0, caret) + v.substring(caret + 1)
-					element.setSelectionRange(caret, caret)
-					element.dispatchEvent(new InputEvent('input'))
-				}
-			}
 			const keyHandlers = {
 				'.button.sk': function(e) {
 					dispatchKeyToDoc(e.currentTarget.getAttribute('data-key'));

--- a/sim.html
+++ b/sim.html
@@ -357,18 +357,17 @@
 				'.button.backspace': function(e) {
 					const element = appFrame.contentDocument.activeElement;
 					if (isInput(element)) {
-						simulateBackspace(element);
+						const v = element.value
+						const caret = element.selectionStart - 1
+						element.value = v.substring(0, caret) + v.substring(caret + 1)
+						element.setSelectionRange(caret, caret)
+						element.dispatchEvent(new InputEvent('input'))
 					} else {
 						dispatchKeyToDoc('Backspace')
 					}
 				},
 				'.button.endcall': function(e) {
-					const element = appFrame.contentDocument.activeElement;
-					if (isInput(element)) {
-						simulateBackspace(element);
-					} else {
-						dispatchKeyToDoc('EndCall')
-					}
+					dispatchKeyToDoc('EndCall')
 				},
 				'.button.lr': function(e) {
 					const element = appFrame.contentDocument.activeElement;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,6 @@
 import { h } from 'preact'
 import { useReducer, useState, useEffect, useLayoutEffect } from 'preact/hooks'
-import { Routes, Softkey, PopupContainer, OfflineIndicator, EndCallHandler } from 'components'
+import { Routes, Softkey, PopupContainer, OfflineIndicator } from 'components'
 import { DirectionContext, I18nContext, SoftkeyContext, PopupContext, FontContext } from 'contexts'
 import { SoftkeyReducer } from 'reducers'
 import { articleTextSize } from 'utils'
@@ -34,7 +34,6 @@ export const App = ({ i18n, dir }) => {
         <PopupContext.Provider value={{ popupState, setPopupState }}>
           <DirectionContext.Provider value={{ dirState, setDirState }}>
             <FontContext.Provider value={{ textSize, setTextSize }}>
-              <EndCallHandler />
               <OfflineIndicator routeUrl={url} />
               <Routes onRouteChange={({ url }) => setUrl(url)} />
               <Softkey dir={dirState} {...state.current} />

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -69,8 +69,27 @@ export const Search = () => {
       setLastFeedIndex(null)
       listRef.current.scrollTop = 0
       setNavigation(0)
+    } else if (inputText) {
+      onInput({ target: { value: '' } })
+      setNavigation(0)
     } else {
       onExitConfirmDialog()
+    }
+  }
+
+  const onKeyEndCall = () => {
+    if (inputText && current.type === 'INPUT') {
+      // simulate backspace event
+      const element = inputRef.current
+      if (element.value !== '' && element.selectionStart > 0) {
+        const v = element.value
+        const caret = element.selectionStart - 1
+        element.value = v.substring(0, caret) + v.substring(caret + 1)
+        element.setSelectionRange(caret, caret)
+        element.dispatchEvent(new InputEvent('input'))
+      }
+    } else {
+      onKeyBackSpace()
     }
   }
 
@@ -137,6 +156,7 @@ export const Search = () => {
     left: allowUsage() ? i18n('softkey-tips') : '',
     onKeyLeft: allowUsage() ? onKeyLeft : null,
     onKeyBackspace: !(inputText && current.type === 'INPUT') && onKeyBackSpace,
+    onKeyEndCall: onKeyEndCall,
     onKeyArrowDown: !loading && onKeyArrowDown,
     onKeyArrowUp: !loading && onKeyArrowUp
   }, [current.type, inputText, isOnline, searchResults, loading])

--- a/src/components/Softkey.js
+++ b/src/components/Softkey.js
@@ -18,6 +18,7 @@ export const Softkey = ({
   onKeyArrowLeft,
   onKeyArrowRight,
   onKeyBackspace,
+  onKeyEndCall,
 
   // direction related prop
   dir = 'ltr',
@@ -40,7 +41,8 @@ export const Softkey = ({
     ArrowUp: onKeyArrowUp,
     ArrowLeft: onKeyFixedArrowLeft || onKeyArrowLeft,
     ArrowRight: onKeyFixedArrowRight || onKeyArrowRight,
-    Backspace: onKeyBackspace
+    Backspace: onKeyBackspace,
+    EndCall: onKeyEndCall
   }
   const onKeyDown = (e) => {
     const key = e.key.toString()


### PR DESCRIPTION
Phabricator Link: https://phabricator.wikimedia.org/project/view/4301/

### Problem Statement

EndCall / Backspace when user on input or search list, see phab ticket for more details

### Solution

 - [x] Add EndCall SoftKey to Search.js
 - [x] Remove Global EndCall Handler
 - [x] Add button to Sim
 - [x] Add Test spec
 - [x] tested on KaiOS device
 - [x] tested on Jio device

### Note

Sim Link: https://wikimedia.github.io/wikipedia-kaios/T311141-EndCall/sim.html
